### PR TITLE
Missing italian translations.

### DIFF
--- a/locales/it.yml
+++ b/locales/it.yml
@@ -43,7 +43,7 @@ it:
       signed_up_but_locked: Iscrizione eseguita correttamente. Però non puoi accedere in quanto il
         tuo account è bloccato.
       signed_up_but_unconfirmed: Ti è stato inviato un messaggio con un link di conferma.
-         Ti invitiamo ad visitare il link per attivare il tuo account.
+         Ti invitiamo a visitare il link per attivare il tuo account.
       update_needs_confirmation: Il tuo account è stato aggiornato, ma dobbiamo verificare
         la tua email. Ti invitiamo a consultare la tua email e cliccare sul link
         di conferma.


### PR DESCRIPTION
italian translations for

MISSING devise.passwords.updated_not_active
MISSING devise.registrations.signed_up_but_inactive
MISSING devise.registrations.signed_up_but_locked
MISSING devise.registrations.signed_up_but_unconfirmed
MISSING devise.registrations.update_needs_confirmation
