### PR TITLE
missing Czech devise locales

### DIFF
--- a/locales/cs.yml
+++ b/locales/cs.yml
@@ -36,6 +36,9 @@ cs:
     registrations:
       destroyed: Nashle! Váš účet byl úspěšně zrušen. Doufáme, že se brzy opět uvidíme.
       signed_up: Vítejte! Registrace byla úspěšná.
+      signed_up_but_inactive: Vítejte! Registrace byla úspěšná. Bohužel se nemůžete přihlásit, protože váš účet ještě není aktivován.
+      signed_up_but_locked: Vítejte! Registrace byla úspěšná. Bohužel se nemůžete přihlásit, protože váš účet je zamknutý.
+      signed_up_unconfirmed: Vítejte! Registrace byla úspěšná. Pro dokončení otevřete aktivační odkaz zaslaný na váš email.
       update_needs_confirmation: Úspěšně jste aktualizoval svů účet, ale ještě musíte
         ověřit svou novou e-mailovou adresu. Zkontrolujte prosím svou schránku a klikněte
         na odkaz pro dokončení ověření vaši nové e-mailové adresy.


### PR DESCRIPTION
I found some untranslated locales in readme:
- MISSING devise.registrations.signed_up_but_inactive
- MISSING devise.registrations.signed_up_but_locked
- MISSING devise.registrations.signed_up_but_unconfirmed

So I added them.

Please, if you can, release a new version and update readme missing locales. Czech should be complet now!
