### PR TITLE
Add filename to spec description

### DIFF
--- a/spec/devise-i18n_spec.rb
+++ b/spec/devise-i18n_spec.rb
@@ -1,7 +1,7 @@
 require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
 
 Dir.glob('locales/*.yml').each do |locale_file|
-  describe 'a locale file' do
+  describe "a devise-i18n #{locale_file} locale file" do
     it_behaves_like 'a valid locale file', locale_file
     it { locale_file.should be_a_subset_of 'locales/en-US.yml' }
   end


### PR DESCRIPTION
It makes easier the CI integration and the reading of rspec output too.

E.g. I using a Jenkins CI environment with ci_reporter gem, and the generated filenames are more friendly, and the test names in the log are more trackable.
