### PR TITLE
Don't modify available locales app

### DIFF
--- a/lib/devise-i18n.rb
+++ b/lib/devise-i18n.rb
@@ -3,7 +3,14 @@ require 'rails'
 module DeviseI18n
   class Railtie < ::Rails::Railtie #:nodoc:
     initializer 'rails-i18n' do |app|
-      I18n.load_path << Dir[File.join(File.expand_path(File.dirname(__FILE__) + '/../locales'), '*.yml')]
+      I18n.available_locales.each do |available_locale|
+        locale_file_path = File.join(File.expand_path(
+          File.dirname(__FILE__) + '/../locales'), "available_locale.yml"
+        )
+        if File.exist?(locale_file_path)
+          I18n.load_path << locale_file_path
+        end
+      end
       I18n.load_path.flatten!
     end
   end


### PR DESCRIPTION
If you use information of `I18n.available_locales` in your app you probably wouldn't modify this information for keep original behaviors of your features, but in loading `devise-i18n` gems your `I18n.available_locales` became :

```
=> [:en, :ar, :az, :bg, :ca, :cs, :da, :de, :el, :"en-GB", :es, :et, :fa, :fi, :fr, :he, :hr, :hu, :id, :is, :it, :ja, :ko, :lt, :lv, :my, :nb, :nl, :no, :pl, :"pt-BR", :pt, :ro, :ru, :sk, :sl, :sv, :th, :tr, :uk, :vi, :"zh-CN", :"zh-HK", :"zh-TW"]
```

it's little much more for my little application ;-)
