### PR TITLE
Not found should say the same as wrong password

### DIFF
--- a/locales/pl.yml
+++ b/locales/pl.yml
@@ -10,7 +10,7 @@ pl:
       invalid: Niepoprawny adres email lub hasło.
       last_attempt: 
       locked: Twoje konto jest zablokowane.
-      not_found_in_database: Nieprawidłowa nazwa użytkownika lub hasło.
+      not_found_in_database: Niepoprawny adres email lub hasło.
       timeout: Sesja wygasła, aby kontynuować zaloguj się ponownie.
       unauthenticated: Aby kontynuować zaloguj lub zarejestruj się.
       unconfirmed: Aby kontynuować aktywuj konto.


### PR DESCRIPTION
Keys `failure.invalid` and `failure.not_found_in_database` should give the same error message for security reasons.
