### PR TITLE
Use ' for strings in nb.yml

### DIFF
--- a/locales/nb.yml
+++ b/locales/nb.yml
@@ -1,57 +1,57 @@
 nb:
   devise:
     confirmations:
-      confirmed: Din konto er aktiveret og du er nå innlogget.
-      send_instructions: Du vil snart motta en epost med instruksjoner for å aktivere din konto.
-      send_paranoid_instructions: Hvis e-postadresen allerede finnes i databasen, vil du om få minutter motta en e-post med instruksjoner om hvordan bekrefte kontoen.
+      confirmed: 'Din konto er aktiveret og du er nå innlogget.'
+      send_instructions: 'Du vil snart motta en epost med instruksjoner for å aktivere din konto.'
+      send_paranoid_instructions: 'Hvis e-postadresen allerede finnes i databasen, vil du om få minutter motta en e-post med instruksjoner om hvordan bekrefte kontoen.'
     failure:
-      already_authenticated: Du er allerede innlogget.
-      inactive: Din konto er ikke aktivert.
-      invalid: Epost-adresse eller passord er ikke gyldig.
-      last_attempt: 
-      locked: Din konto er låst.
-      not_found_in_database: Ugyldig e-post eller passord.
-      timeout: Din sesjon er utløpt. Logg inn igjen for å kunne fortsette.
-      unauthenticated: Du må logge inn eller registrere deg for å kunne fortsette.
-      unconfirmed: Du må bekrefte kontoen din for å kunne fortsette.
+      already_authenticated: 'Du er allerede innlogget.'
+      inactive: 'Din konto er ikke aktivert.'
+      invalid: 'Epost-adresse eller passord er ikke gyldig.'
+      last_attempt:
+      locked: 'Din konto er låst.'
+      not_found_in_database: 'Ugyldig e-post eller passord.'
+      timeout: 'Din sesjon er utløpt. Logg inn igjen for å kunne fortsette.'
+      unauthenticated: 'Du må logge inn eller registrere deg for å kunne fortsette.'
+      unconfirmed: 'Du må bekrefte kontoen din for å kunne fortsette.'
     mailer:
       confirmation_instructions:
-        subject: Bekreftelsesinstruksjoner
+        subject: 'Bekreftelsesinstruksjoner'
       reset_password_instructions:
-        subject: Nullstilling av passord
+        subject: 'Nullstilling av passord'
       unlock_instructions:
-        subject: Gjenåpning av konto
+        subject: 'Gjenåpning av konto'
     omniauth_callbacks:
-      failure: Kunne ikke autorisere deg fra %{kind} fordi "%{reason}".
-      success: Vellykket autorisering fra %{kind}.
+      failure: 'Kunne ikke autorisere deg fra %{kind} fordi "%{reason}".'
+      success: 'Vellykket autorisering fra %{kind}.'
     passwords:
-      no_token: For å få tilgang til denne siden må du klikket deg inn fra en epost for å sette passord på nytt. Hvis du klikket deg inn fra en slik epost, sørg for at hele lenken ble brukt.
-      send_instructions: Du vil snart motta en epost med instruksjoner for å nullstille passordet ditt.
-      send_paranoid_instructions: Hvis e-postadressen allerede finnes i databasen, vil du motta en lenke for å sette passordet på nytt
-      updated: Ditt passord er endret og du er nå innlogget.
-      updated_not_active: Passordet er endret.
+      no_token: 'For å få tilgang til denne siden må du klikket deg inn fra en epost for å sette passord på nytt. Hvis du klikket deg inn fra en slik epost, sørg for at hele lenken ble brukt.'
+      send_instructions: 'Du vil snart motta en epost med instruksjoner for å nullstille passordet ditt.'
+      send_paranoid_instructions: 'Hvis e-postadressen allerede finnes i databasen, vil du motta en lenke for å sette passordet på nytt'
+      updated: 'Ditt passord er endret og du er nå innlogget.'
+      updated_not_active: 'Passordet er endret.'
     registrations:
-      destroyed: Farvel. Din konto er nå slettet.
-      signed_up: Velkommen! Din registrering er vellykket.
-      signed_up_but_inactive: Du er nå registrert. Men vi kan ikke logge deg inn når kontoen ikke er aktivert.
-      signed_up_but_locked: Du er nå registrert. Men vi kan ikke legge deg inn fordi kontoen er låst.
-      signed_up_but_unconfirmed: En melding med lenke for bekreftelse er sendt til e-postadressen. Vennligst åpne lenken for å aktivere kontoen.
-      update_needs_confirmation: Kontoen er nå oppdatert. Men vi må bekrefte den nye adressen. Vennligst sjekk e-posten og klikk på lenken for å bekrefte din nye e-postadresse.
-      updated: Din profil er oppdatert.
+      destroyed: 'Farvel. Din konto er nå slettet.'
+      signed_up: 'Velkommen! Din registrering er vellykket.'
+      signed_up_but_inactive: 'Du er nå registrert. Men vi kan ikke logge deg inn når kontoen ikke er aktivert.'
+      signed_up_but_locked: 'Du er nå registrert. Men vi kan ikke legge deg inn fordi kontoen er låst.'
+      signed_up_but_unconfirmed: 'En melding med lenke for bekreftelse er sendt til e-postadressen. Vennligst åpne lenken for å aktivere kontoen.'
+      update_needs_confirmation: 'Kontoen er nå oppdatert. Men vi må bekrefte den nye adressen. Vennligst sjekk e-posten og klikk på lenken for å bekrefte din nye e-postadresse.'
+      updated: 'Din profil er oppdatert.'
     sessions:
-      signed_in: Du er nå innlogget.
-      signed_out: Du er nå logget ut.
+      signed_in: 'Du er nå innlogget.'
+      signed_out: 'Du er nå logget ut.'
     unlocks:
-      send_instructions: Du vil snart motta en epost med instruksjon for å gjenåpne din konto.
-      send_paranoid_instructions: Hvis kontoen eksisterer, vil du om få minutter motta en e-post med instruksjoner om hvordan du låser opp den.
-      unlocked: Din konto er gjenåpnet og du er nå innlogget.
+      send_instructions: 'Du vil snart motta en epost med instruksjon for å gjenåpne din konto.'
+      send_paranoid_instructions: 'Hvis kontoen eksisterer, vil du om få minutter motta en e-post med instruksjoner om hvordan du låser opp den.'
+      unlocked: 'Din konto er gjenåpnet og du er nå innlogget.'
   errors:
     messages:
-      already_confirmed: har allerede blitt bekreftet. Prøv å logg inn.
-      confirmation_period_expired: må bekreftes innen %{period}, vennligst be om et nytt
-      expired: har utløpt, vennligst forespør en ny
-      not_found: ikke funnet
-      not_locked: var ikke låst
+      already_confirmed: 'har allerede blitt bekreftet. Prøv å logg inn.'
+      confirmation_period_expired: 'må bekreftes innen %{period}, vennligst be om et nytt'
+      expired: 'har utløpt, vennligst forespør en ny'
+      not_found: 'ikke funnet'
+      not_locked: 'var ikke låst'
       not_saved:
         one: 'Én feil gjorde at %{resource} ikke kunne lagres:'
         other: '%{count} feil gjorde at %{resource} ikke kunne lagres:'


### PR DESCRIPTION
nb.yml was missing ' on all the strings. It's more a formatting preference than a requirement.
