### PR TITLE
Translate missing sv.yml translations

### DIFF
--- a/locales/sv.yml
+++ b/locales/sv.yml
@@ -1,57 +1,61 @@
 sv:
   devise:
     confirmations:
-      confirmed: Ditt konto har bekräftats. Du är nu inloggad.
-      send_instructions: Du kommer att få epost med instruktioner om hur du kan bekräfta ditt konto inom några minuter.
-      send_paranoid_instructions: Om din epostadress är i vår databas, kommer du att få ett epost med instruktioner om hur du ska aktivera ditt konto inom några minuter.
+      confirmed: 'Ditt konto har bekräftats. Du är nu inloggad.'
+      send_instructions: 'Du kommer att få epost med instruktioner om hur du kan bekräfta ditt konto inom några minuter.'
+      send_paranoid_instructions: 'Om din epost är i vår databas, kommer du att få ett mail med instruktioner om hur du ska aktivera ditt konto inom några minuter.'
     failure:
-      already_authenticated: Du är redan inloggad.
-      inactive: Ditt konto har inte aktiverats ännu.
-      invalid: Ogiltig epost eller lösenord.
-      last_attempt: 
-      locked: Ditt konto är låst.
-      not_found_in_database: Ogiltig epost eller lösenord.
-      timeout: Din session är inte längre giltig, vänligen logga in igen för att fortsätta.
-      unauthenticated: Du måste logga in eller skapa ett konto innan du kan fortsätta.
-      unconfirmed: Du måste bekräfta ditt konto innan du kan fortsätta.
+      already_authenticated: 'Du har redan loggat in.'
+      inactive: 'Ditt konto har inte aktiverats ännu.'
+      invalid: 'Ogiltigt användarnamn eller lösenord.'
+      locked: 'Ditt konto är låst.'
+      last_attempt: "Du har ett till inloggningsförsök före ditt konto blir låst."
+      not_found_in_database: "Ogiltigt användarnamn eller lösenord."
+      timeout: 'Din session är inte längre giltig, vänligen logga in igen för att fortsätta.'
+      unauthenticated: 'Du måste logga in eller skapa ett konto innan du kan fortsätta.'
+      unconfirmed: 'Du måste bekräfta ditt konto innan du kan fortsätta.'
     mailer:
       confirmation_instructions:
-        subject: Instruktioner för bekräftning av konto
+        subject: 'ApoEx - Instruktioner om bekräftning av konto'
       reset_password_instructions:
-        subject: Instruktioner för återställning av lösenord
+        subject: 'ApoEx - Instruktioner om att skapa nytt lösenord'
       unlock_instructions:
-        subject: Instruktioner för upplåsning av konto
+        subject: 'ApoEx - Instruktioner om upplåsning av konto'
     omniauth_callbacks:
-      failure: Kunde inte autentisera dig med %{kind} för "%{reason}".
-      success: Autentiserat med %{kind}-konto.
+      failure: 'Kunde inte autentisera dig med %{kind} för "%{reason}".'
+      success: 'Autentiserat med %{kind}-konto.'
     passwords:
-      no_token: Tillgång till den här sidan kräver att du kommer från ett mejl som sätter tillbaka ditt lösenord. Om du kom hit från ett sånt mejl, säkerställ att du har använt hela URL:en.
-      send_instructions: Du kommer få epost med instruktioner för hur du kan återställa ditt lösenord inom några minuter.
-      send_paranoid_instructions: Om din epostadress finns i vår databas kommer du att få en lösenordslänk skickad till din epost.
-      updated: Ditt lösenord har uppdaterats. Du är nu inloggad.
-      updated_not_active: Ditt lösenord uppdaterades.
+      no_token: "Det går bara att komma åt denna sida ifrån ett epostmeddelande för att återställa sitt lösenord. Ifall detta är fallet, vänligen kolla så att du öppnade hela URL:en i meddelandet."
+      send_instructions: 'Du kommer få epost med instruktioner om hur du kan återställa ditt lösenord inom några minuter.'
+      send_paranoid_instructions: "Om din epost är i vår databas, kommer du att få en lösenordslänk till din mail."
+      updated: 'Ditt lösenord har uppdaterats. Du är nu inloggad.'
+      updated_not_active: "Ditt lösenord har uppdaterats."
     registrations:
-      destroyed: Hej då! Ditt konto har avregistrerats. Vi hoppas få se dig snart igen.
-      signed_up: Välkommen! Ditt nya konto har skapats.
-      signed_up_but_inactive: Du är nu registrerad. Däremot kunde vi inte logga in dig, eftersom ditt konto ännu inte aktiverats.
-      signed_up_but_locked: Du är nu registrerad. Däremot kunde vi inte logga in dig, eftersom ditt konto är låst.
-      signed_up_but_unconfirmed: Ett meddelande med en länk för att bekräfta din registrering har skickats till din epostadress. Följ länken för att aktivera ditt konto.
-      update_needs_confirmation: Ditt konto uppdaterades, men vi behöver verifiera din nya epostadress. Kontrollera din epost och klicka på länken för att bekräfta din nya epostadress.
-      updated: Ditt konto har uppdaterats.
+      destroyed: 'Hej då! Ditt konto har avregistrerats. Vi hoppas få se dig snart igen.'
+      signed_up: 'Ett nytt konto har skapats. En bekräftelse har skickats till din epost.'
+      signed_up_but_inactive: 'Du är registerad men vi kan inte logga in dig eftersom ditt konto ännu inte är aktiverat.'
+      signed_up_but_locked: 'Du är registerad men vi kan inte logga in dig eftersom ditt konto är låst'
+      signed_up_but_unconfirmed: 'En meddelande med en bekräftelse-länk har skickats till din e-postadress. Klicka på länken för att aktivera ditt konto.'
+      update_needs_confirmation: "Ditt konto har uppdaterats, men vi behöver bekräfta din nya epost. Vänligen kolla din epost och klicka på bekräfta-länken som har skickats till dig för att slutföra uppdateringen av din epost."
+      updated: 'Ditt konto har uppdaterats.'
     sessions:
-      signed_in: Loggade in.
-      signed_out: Loggade ut.
+      signed_in: 'Loggade in.'
+      signed_out: 'Loggade ut.'
     unlocks:
-      send_instructions: Du kommer få epost med instruktioner om hur du kan låsa upp ditt konto inom några minuter.
-      send_paranoid_instructions: Om ditt konto finns, kommer du att få ett email med instruktioner om hur du låser upp det inom några minuter.
-      unlocked: Ditt konto har låsts upp. Du är nu inloggad.
+      send_instructions: 'Du kommer få epost med instruktioner om hur du kan låsa upp ditt konto inom några minuter.'
+      send_paranoid_instructions: 'Om ditt konto finns, kommer du att få ett epost med instruktioner om hur du låser upp det inom några minuter.'
+      unlocked: 'Ditt konto har låsts upp. Du är nu inloggad.'
+    session:
+      contact:
+        signed_in: ""
+        signed_out: ""
   errors:
     messages:
-      already_confirmed: är redan bekräftad, vänligen logga in igen
-      confirmation_period_expired: behöver bekräftas inom %{period}. Vänligen begär en ny
-      expired: är inte längre giltig. Vänligen begär en ny
-      not_found: hittades inte
-      not_locked: var inte låst
+      already_confirmed: "är redan bekräftad, vänligen logga in igen"
+      confirmation_period_expired: "måste bekräftas inom %{period}, vänligen begär en ny"
+      expired: "har löpt ut, var god begär en ny"
+      not_found: "hittades inte"
+      not_locked: "var inte låst"
       not_saved:
-        one: '1 fel hindrade denna %{resource} från att sparas:'
-        other: '%{count} fel hindrade denna %{resource} från att sparas:'
+        one: "1 fel hindrade denna %{resource} från att sparas:"
+        other: "%{count} fel hindrade denna %{resource} från att sparas:"


### PR DESCRIPTION
Keys:
- last_attempt
- not_found_in_database
- no_token
- updated_not_active
- update_needs_confirmation
- confirmation_period_expired

Also:
- change "email" -> "epost" for consistency
- one or two other minor adjustments
