### PR TITLE
remove obsolete i18n initializer

### DIFF
--- a/lib/devise-i18n.rb
+++ b/lib/devise-i18n.rb
@@ -2,9 +2,5 @@ require 'rails'
 
 module DeviseI18n
   class Engine < ::Rails::Engine #:nodoc:
-    initializer 'rails-i18n' do |app|
-      I18n.load_path << Dir[File.join(File.expand_path(File.dirname(__FILE__) + '/../locales'), '*.yml')]
-      I18n.load_path.flatten!
-    end
   end
 end


### PR DESCRIPTION
I forgot to add this change in #96. That is now done by [Rails Engine](https://github.com/rails/rails/blob/master/railties/lib/rails/engine.rb#L578), thats the real reason for #96.
