### PR TITLE
Update zh-CN.yml

### DIFF
--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -1,7 +1,7 @@
 zh-CN:
   devise:
     confirmations:
-      confirmed: 您的帐号已经确认，您现在已登录.
+      confirmed: 您的帐号已经确认，请登录.
       send_instructions: 几分钟后，您将收到确认帐号的电子邮件.
       send_paranoid_instructions: 如果您的邮箱存在于我们的数据库中，您将收到一封确认账号的邮件.
     failure:


### PR DESCRIPTION
Devise 3.1 no longer signs the user automatically in after confirmation.

ruby on rails - Avoid sign-in after confirmation link click using devise gem? - Stack Overflow
http://stackoverflow.com/questions/18655334/avoid-sign-in-after-confirmation-link-click-using-devise-gem
