### PR TITLE
Improve the quality of the Dutch translations

### DIFF
--- a/rails/locales/nl.yml
+++ b/rails/locales/nl.yml
@@ -3,14 +3,14 @@ nl:
     confirmations:
       confirmed: Je account is bevestigd.
       send_instructions: Je ontvangt via e-mail instructies hoe je je account kan bevestigen.
-      send_paranoid_instructions: Als we je e-mail adres terugvinden in onze database, zal je binnen enkele ogenblikken een e-mail ontvangen met de instructies  hoe je je account kan bevestigen.
+      send_paranoid_instructions: Als we je e-mailadres terugvinden in onze database, zal je binnen enkele ogenblikken een e-mail ontvangen met instructies hoe je je account kan bevestigen.
     failure:
       already_authenticated: Je bent reeds aangemeld.
       inactive: Je account is nog niet geactiveerd.
       invalid: Ongeldig e-mail of wachtwoord.
       last_attempt: Je hebt nog één poging voordat je account vergrendeld wordt.
       locked: Je account is vergrendeld.
-      not_found_in_database: Ongeldige email of wachtwoord.
+      not_found_in_database: Ongeldig e-mail of wachtwoord.
       timeout: Je sessie is verlopen, meld je opnieuw aan om door te gaan.
       unauthenticated: Je dient je aan te melden of in te schrijven om door te gaan.
       unconfirmed: Je dient eerst je account te bevestigen.
@@ -18,41 +18,41 @@ nl:
       confirmation_instructions:
         subject: Bevestiging
       reset_password_instructions:
-        subject: Wachtwoord resetten
+        subject: Instructies om je wachtwoord opnieuw in te stellen
       unlock_instructions:
         subject: Ontgrendelinstructies
     omniauth_callbacks:
       failure: We konden je niet aanmelden op je %{kind} omdat "%{reason}".
       success: Je bent succesvol ingelogd op je %{kind} account.
     passwords:
-      no_token: Deze pagina is alleen bereikbaar via een wachtwoord reset e-mail. Als je wel via een wachtwoord reset email komt, zorg er dan voor dat je de volledige URL gebruikt.
-      send_instructions: Je ontvangt via e-mail instructies hoe je je wachtwoord moet resetten.
-      send_paranoid_instructions: Als we je e-mail adres terugvinden in onze database, zal je binnen enkele ogenblikken via e-mail een link ontvangen om je paswoord te resetten.
+      no_token: Deze pagina is alleen bereikbaar via een wachtwoord vergeten e-mail. Als je wel via een wachtwoord vergeten e-mail komt, zorg er dan voor dat je de volledige URL gebruikt.
+      send_instructions: Je ontvangt een e-mail met instructies hoe je je wachtwoord opnieuw kan instellen.
+      send_paranoid_instructions: Als we je e-mailadres terugvinden in onze database, zal je binnen enkele ogenblikken via e-mail een link ontvangen om je wachtwoord opnieuw in te stellen.
       updated: Je wachtwoord is gewijzigd. Je bent nu aangemeld.
-      updated_not_active: Je wachtwoord werd met succes gewijzigd.
+      updated_not_active: Je wachtwoord is met succes gewijzigd.
     registrations:
       destroyed: Je account is verwijderd, wellicht tot ziens!
       signed_up: Je bent ingeschreven.
       signed_up_but_inactive: Je bent ingeschreven, maar we konden je niet inloggen omdat je account nog niet is geactiveerd.
-      signed_up_but_locked: Je bent ingeschreven, maar we konden je niet inloggen omdat je account is gelocked.
-      signed_up_but_unconfirmed: Een e-mail met een confirmatie link is naar je e-mail adres gestuurd. Open de link in je browser om je account te activeren.
-      update_needs_confirmation: Je account is geüpdatet, maar we moeten je e-mail adres nog valideren. Een e-mail met een confirmatie link is naar je e-mail adres gestuurd. Open de link in je browser om je e-mail adres te confirmeren.
-      updated: Je account gegevens zijn opgeslagen.
+      signed_up_but_locked: Je bent ingeschreven, maar we konden je niet inloggen omdat je account is vergrendeld.
+      signed_up_but_unconfirmed: Een e-mail met een confirmatielink is naar je e-mailadres gestuurd. Open de link in je browser om je account te activeren.
+      update_needs_confirmation: Je account is bijgewerkt, maar we moeten je e-mailadres nog valideren. Een e-mail met een confirmatielink is naar je e-mailadres gestuurd. Open de link in je browser om je e-mailadres te confirmeren.
+      updated: Je accountgegevens zijn opgeslagen.
     sessions:
-      already_signed_out: U bent succesvol uitgelogd.
+      already_signed_out: Je bent succesvol uitgelogd.
       signed_in: Je bent succesvol ingelogd.
       signed_out: Je bent succesvol uitgelogd.
     unlocks:
-      send_instructions: Je ontvangt via e-mail instructies hoe je je account kan unlocken.
-      send_paranoid_instructions: Als we je e-mail adres terugvinden in onze database, zal je binnen enkele ogenblikken via e-mail, de instructies ontvangen hoe je je account kan unlocken.
-      unlocked: Je account is ge-unlocked. Je kan nu weer inloggen.
+      send_instructions: Je ontvangt via e-mail instructies hoe je je account kan ontgrendelen.
+      send_paranoid_instructions: Als we je e-mailadres terugvinden in onze database, zal je binnen enkele ogenblikken een e-mail ontvangen met instructies hoe je je account kan ontgrendelen.
+      unlocked: Je account is ontgrendeld. Je kan nu weer inloggen.
   errors:
     messages:
       already_confirmed: is reeds bevestigd
-      confirmation_period_expired: moet binnen %{period} worden bevestigd, a.u.b. plaats een nieuw verzoek
+      confirmation_period_expired: moet binnen %{period} worden bevestigd, plaats a.u.b. een nieuw verzoek
       expired: is verlopen, vraag een nieuwe aan
       not_found: niet gevonden
       not_locked: is niet gesloten
       not_saved:
-        one: '1 error verhinderde het opslaan van deze %{resource}:'
-        other: "%{count} errors verhinderde het opslaan van deze %{resource}:"
+        one: 'Een fout verhinderde het opslaan van deze %{resource}:'
+        other: "%{count} fouten verhinderde het opslaan van deze %{resource}:"


### PR DESCRIPTION
This improves the quality of the Dutch translations.

- It fixes 2 or 3 outright errors.
- Uses consistent spelling throughout (eg. "email" vs. "e-mail", "unlock" vs.
  "ontgrendelen", etc).
- Uses actual Dutch words, rather than English or Dutchified English words (eg.
  "fouten" instead of "errors", "vergrendeld" instead of "geunlocked", etc).