### PR TITLE
fix de-CH typo

### DIFF
--- a/rails/locales/de-CH.yml
+++ b/rails/locales/de-CH.yml
@@ -33,8 +33,8 @@ de-CH:
         instruction: 'Folgen Sie dem untenstehenden Link, um Ihr Konto zu bestätigen:'
         subject: Anleitung zur Bestätigung Ihres Accounts
       password_change:
-        greeting: 
-        message: 
+        greeting:
+        message:
         subject: Passwort geändert
       reset_password_instructions:
         action: Passwort ändern
@@ -89,7 +89,7 @@ de-CH:
       already_signed_out: Erfolgreich abgemeldet.
       new:
         sign_in: Anmelden
-      signed_in: Erfolgreich abgemeldet.
+      signed_in: Erfolgreich angemeldet.
       signed_out: Erfolgreich abgemeldet.
     shared:
       links:


### PR DESCRIPTION
swiss is supposed to be likewise the german version https://github.com/tigrish/devise-i18n/blob/master/rails/locales/de.yml#L92