### PR TITLE
Fixed pt-BR typo

### DIFF
--- a/rails/locales/pt-BR.yml
+++ b/rails/locales/pt-BR.yml
@@ -63,7 +63,7 @@ pt-BR:
       new:
         forgot_your_password: Esqueceu sua senha?
         send_me_reset_password_instructions: Enviar instruções para redefinição da senha
-      no_token: Você não pode acessar esta página sem estar logado. Se você veio de um email de lembre de senha, por favor certifique-se de ter  digitado a URL corretamente.
+      no_token: Você não pode acessar esta página sem estar logado. Se você veio de um email de redefinição de senha, por favor certifique-se de ter digitado a URL corretamente.
       send_instructions: Dentro de minutos, você receberá um email com as instruções de reinicialização da sua senha.
       send_paranoid_instructions: Se o seu email existir em nosso banco de dados, você receberá um email com um link para recuperação da senha.
       updated: A sua senha foi alterada com sucesso. Você está autenticado.


### PR DESCRIPTION
Fixed a typo in "pt-BR". 
The word "lembre" was incorrect. Perhaps the intent was to be "lembrete", but "redefinição" is the most appropriate here.