### PR TITLE
Changed email to email address in failure message

### DIFF
--- a/rails/locales/nl.yml
+++ b/rails/locales/nl.yml
@@ -21,10 +21,10 @@ nl:
     failure:
       already_authenticated: Je bent reeds aangemeld.
       inactive: Je account is nog niet geactiveerd.
-      invalid: Ongeldig e-mail of wachtwoord.
+      invalid: Ongeldig e-mailadres of wachtwoord.
       last_attempt: Je hebt nog één poging voordat je account vergrendeld wordt.
       locked: Je account is vergrendeld.
-      not_found_in_database: Ongeldig e-mail of wachtwoord.
+      not_found_in_database: Ongeldig e-mailadres of wachtwoord.
       timeout: Je sessie is verlopen, meld je opnieuw aan om door te gaan.
       unauthenticated: Je dient je aan te melden of in te schrijven om door te gaan.
       unconfirmed: Je dient eerst je account te bevestigen.


### PR DESCRIPTION
Hi,

I updated the Dutch locale with a more appropriate message on failure by expanding "email" into "email address". Would it be possible to merge this into your repository? Thanks!