### PR TITLE
Pluralizations for activerecord.models.user

### DIFF
--- a/rails/locales/af.yml
+++ b/rails/locales/af.yml
@@ -10,7 +10,9 @@ af:
         reset_password_token: Herstel wagwoord egtheidsbewys
         unlock_token: Ontsluit egtheidsbewys
     models:
-      user: Gebruiker
+      user:
+        one: Gebruiker
+        other: Gebruikers
   devise:
     confirmations:
       confirmed: Jou e-posadres is suksesvol bevestig.

--- a/rails/locales/ar.yml
+++ b/rails/locales/ar.yml
@@ -7,10 +7,16 @@ ar:
         password: "كلمة المرور"
         password_confirmation: "تأكيد كلمة المرور"
         remember_me: "تذكرني"
-        reset_password_token: 
-        unlock_token: 
+        reset_password_token:
+        unlock_token:
     models:
-      user: "المستخدم"
+      user:
+        zero:
+        one: "المستخدم"
+        two:
+        few:
+        many:
+        other: "المستخدمين"
   devise:
     confirmations:
       confirmed: "تمّ تأكيد الحساب بنجاح، وتمّ تسجيل الدّخول."
@@ -35,9 +41,9 @@ ar:
         instruction: "يمكن تأكيد حساب بريدك الإلكتروني من خلال الرابط التّالي:"
         subject: "تعليمات تأكيد الحساب"
       password_change:
-        greeting: 
-        message: 
-        subject: 
+        greeting:
+        message:
+        subject:
       reset_password_instructions:
         action: "غيّر كلمة السر"
         greeting: "مرحبا %{recipient}"
@@ -88,7 +94,7 @@ ar:
       update_needs_confirmation: "تُم تعديل الحساب بنجاح، يرجى تأكيد البريد الإلكتروني. الرجاء الذهاب الى البريد الإلكتروني والضغط على الرابط الموجود للانتهاء من عمليّة التاكيد."
       updated: "تمّ تعديل الحساب بنجاح."
     sessions:
-      already_signed_out: 
+      already_signed_out:
       new:
         sign_in: "سجّلْ الدخول"
       signed_in: "تمّ تسجيل الدخول."
@@ -121,4 +127,4 @@ ar:
         one: "مشكلة واحدة منعت %{resource} من التخزين بنجاح."
         other: "%{count} مشكلة منعت %{resource} من التخزين بنجاح."
         two: "مشكلتين منعتا %{resource} من التخزين بنجاح."
-        zero: 
+        zero:

--- a/rails/locales/az.yml
+++ b/rails/locales/az.yml
@@ -2,20 +2,22 @@ az:
   activerecord:
     attributes:
       user:
-        current_password: 
-        email: 
-        password: 
-        password_confirmation: 
-        remember_me: 
-        reset_password_token: 
-        unlock_token: 
+        current_password:
+        email:
+        password:
+        password_confirmation:
+        remember_me:
+        reset_password_token:
+        unlock_token:
     models:
-      user: 
+      user:
+        one:
+        other: 
   devise:
     confirmations:
       confirmed: Hesabınız uğurla təstiqləndi. Hazırda siz hesabınıza daxil olmuşsunuz.
       new:
-        resend_confirmation_instructions: 
+        resend_confirmation_instructions:
       send_instructions: Bir neçə dəqiqə ərzində hesabınızı təstiqləmək üçün sizə email göndəriləcəkdir.
       send_paranoid_instructions: "Əgər sizin email ünvanı bazada varsa, bir neçə dəqiqə ərzində hesabınızı təstiqləmək üçün email sizə göndəriləcəkdir."
     failure:
@@ -30,39 +32,39 @@ az:
       unconfirmed: Davam etmək üçün hesabınızı təstiqləməlisiniz.
     mailer:
       confirmation_instructions:
-        action: 
-        greeting: 
-        instruction: 
+        action:
+        greeting:
+        instruction:
         subject: Hesabın təstiqlənməsi
       password_change:
-        greeting: 
-        message: 
-        subject: 
+        greeting:
+        message:
+        subject:
       reset_password_instructions:
-        action: 
-        greeting: 
-        instruction: 
-        instruction_2: 
-        instruction_3: 
+        action:
+        greeting:
+        instruction:
+        instruction_2:
+        instruction_3:
         subject: "Şifrənin yenilənməsi"
       unlock_instructions:
-        action: 
-        greeting: 
-        instruction: 
-        message: 
+        action:
+        greeting:
+        instruction:
+        message:
         subject: Hesabın blokdan çıxardılması
     omniauth_callbacks:
       failure: '"%{reason}" səbəbindən sizi %{kind} autentikasiya etmək mümkün olmadı.'
       success: "%{kind} hesabıyla uğurla daxil oldunuz."
     passwords:
       edit:
-        change_my_password: 
-        change_your_password: 
-        confirm_new_password: 
-        new_password: 
+        change_my_password:
+        change_your_password:
+        confirm_new_password:
+        new_password:
       new:
-        forgot_your_password: 
-        send_me_reset_password_instructions: 
+        forgot_your_password:
+        send_me_reset_password_instructions:
       no_token: You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided.
       send_instructions: Siz bir neçə dəqiqə ərazində, şifrənizi necə dəyişmək haqqında email qəbul edəcəksiniz.
       send_paranoid_instructions: "Əgər sizin email ünvanı bazada varsa, bir neçə dəqiqə ərazində, şifrənizi necə dəyişmək haqqında email qəbul edəcəksiniz."
@@ -71,16 +73,16 @@ az:
     registrations:
       destroyed: Hesabınız sistemimizdən uğurla çıxarıldı.
       edit:
-        are_you_sure: 
-        cancel_my_account: 
-        currently_waiting_confirmation_for_email: 
-        leave_blank_if_you_don_t_want_to_change_it: 
-        title: 
-        unhappy: 
-        update: 
-        we_need_your_current_password_to_confirm_your_changes: 
+        are_you_sure:
+        cancel_my_account:
+        currently_waiting_confirmation_for_email:
+        leave_blank_if_you_don_t_want_to_change_it:
+        title:
+        unhappy:
+        update:
+        we_need_your_current_password_to_confirm_your_changes:
       new:
-        sign_up: 
+        sign_up:
       signed_up: Təbriklər! Siz uğurla qeydiyyatdan keçdiniz.
       signed_up_but_inactive: Siz uğurla qeydiyyatdan keçdiniz. Halbuki, sistemə yalnız hesabınızı aktiv etdikdən sonra daxil ola bilərsiniz.
       signed_up_but_locked: Siz uğurla qeydiyyatdan keçdiniz. Ancaq hesabınız blokda olduğu üçün biz sizi sistemə daxil edə bilmirik.
@@ -90,21 +92,21 @@ az:
     sessions:
       already_signed_out: Ugurlu cıxış.
       new:
-        sign_in: 
+        sign_in:
       signed_in: Sistemə uğurla daxil oldunuz.
       signed_out: Sistemdən uğurla çıxdınız.
     shared:
       links:
-        back: 
-        didn_t_receive_confirmation_instructions: 
-        didn_t_receive_unlock_instructions: 
-        forgot_your_password: 
-        sign_in: 
-        sign_in_with_provider: 
-        sign_up: 
+        back:
+        didn_t_receive_confirmation_instructions:
+        didn_t_receive_unlock_instructions:
+        forgot_your_password:
+        sign_in:
+        sign_in_with_provider:
+        sign_up:
     unlocks:
       new:
-        resend_unlock_instructions: 
+        resend_unlock_instructions:
       send_instructions: Bir neçə dəqiqə ərzində hesabınızı blokdan çıxarmaq üçün sizə email göndəriləcəkdir.
       send_paranoid_instructions: "Əgər bazada belə hesab varsa, bir neçə dəqiqə ərzində hesabınızı blokdan çıxarmaq üçün sizə email göndəriləcəkdir."
       unlocked: Hesabınız uğurlar blokdan çıxarıldı, davam etmək üçün zəhmət olmasa daxil olun

--- a/rails/locales/be.yml
+++ b/rails/locales/be.yml
@@ -10,7 +10,9 @@ be:
         reset_password_token: "Спасылка скіду пароля"
         unlock_token: "Токен разблакоўкі"
     models:
-      user: "Карыстальнік"
+      user:
+        one: "Карыстальнік"
+        other: "Карыстальнікаў"
   devise:
     confirmations:
       confirmed: "Ваш адрас эл. пошты паспяхова пацверджаны."

--- a/rails/locales/bg.yml
+++ b/rails/locales/bg.yml
@@ -10,7 +10,9 @@ bg:
         reset_password_token: "Код за промяна на парола"
         unlock_token: "Код за отключване на профил"
     models:
-      user: "Потребител"
+      user:
+        one: "Потребител"
+        other: "Потребители"
   devise:
     confirmations:
       confirmed: "Регистрацията Ви е потвърдена."

--- a/rails/locales/bn.yml
+++ b/rails/locales/bn.yml
@@ -2,20 +2,22 @@ bn:
   activerecord:
     attributes:
       user:
-        current_password: 
-        email: 
-        password: 
-        password_confirmation: 
-        remember_me: 
-        reset_password_token: 
-        unlock_token: 
+        current_password:
+        email:
+        password:
+        password_confirmation:
+        remember_me:
+        reset_password_token:
+        unlock_token:
     models:
-      user: 
+      user:
+        one:
+        other: 
   devise:
     confirmations:
       confirmed: "আপনার ইমেল ঠিকানা সফলভাবে নিশ্চিত করা হয়েছে।"
       new:
-        resend_confirmation_instructions: 
+        resend_confirmation_instructions:
       send_instructions: "আপনি কয়েক মিনিটের মধ্যে আপনার ইমেল ঠিকানা নিশ্চিত করার জন্যে নির্দেশাবলী সহ একটি ইমেল পাবেন।"
       send_paranoid_instructions: "আপনার ইমেল ঠিকানা আমাদের ডাটাবেসের মধ্যে উপস্থিত থাকলে, আপনি কয়েক মিনিটের মধ্যে আপনার ইমেল ঠিকানা নিশ্চিত করার জন্যে নির্দেশাবলী সহ একটি ইমেল পাবেন।"
     failure:
@@ -30,39 +32,39 @@ bn:
       unconfirmed: "আপনি চালিয়ে যাওয়ার আগে আপনার ইমেল ঠিকানা নিশ্চিত করতে হবে।"
     mailer:
       confirmation_instructions:
-        action: 
-        greeting: 
-        instruction: 
+        action:
+        greeting:
+        instruction:
         subject: "নিশ্চিতকরণ নির্দেশাবলী"
       password_change:
-        greeting: 
-        message: 
-        subject: 
+        greeting:
+        message:
+        subject:
       reset_password_instructions:
-        action: 
-        greeting: 
-        instruction: 
-        instruction_2: 
-        instruction_3: 
+        action:
+        greeting:
+        instruction:
+        instruction_2:
+        instruction_3:
         subject: "পাসওয়ার্ড রিসেট করার নির্দেশাবলী"
       unlock_instructions:
-        action: 
-        greeting: 
-        instruction: 
-        message: 
+        action:
+        greeting:
+        instruction:
+        message:
         subject: "আনলক করার নির্দেশাবলী"
     omniauth_callbacks:
       failure: আপনি %{kind} থেকে এসেছেন, এটি প্রমান করা যায়নি কারন "%{reason}".
       success: "আপনার %{kind} থেকে আসা নিশ্চিত হয়েছে।"
     passwords:
       edit:
-        change_my_password: 
-        change_your_password: 
-        confirm_new_password: 
-        new_password: 
+        change_my_password:
+        change_your_password:
+        confirm_new_password:
+        new_password:
       new:
-        forgot_your_password: 
-        send_me_reset_password_instructions: 
+        forgot_your_password:
+        send_me_reset_password_instructions:
       no_token: "আপনি পাসওয়ার্ড রিসেট ইমেইল থেকে আসা ছাড়া এই পৃষ্ঠায় প্রবেশ করতে পারবেন না। আপনি যদি পাসওয়ার্ড রিসেট ইমেইল থেকে এসে থাকেন, তাহলে নিশ্চিত করুন যে আপনি সম্পুর্ণ লিঙ্ক ব্যবহার করেছেন।"
       send_instructions: "আপনি কয়েক মিনিটের মধ্যে আপনার পাসওয়ার্ড পুনরুদ্ধার নির্দেশাবলী সহ একটি ইমেল পাবেন।"
       send_paranoid_instructions: "আপনার ইমেল ঠিকানা আমাদের ডাটাবেসের মধ্যে উপস্থিত থাকলে, আপনি কয়েক মিনিটের মধ্যে আপনার ইমেইল ঠিকানায় একটি পাসওয়ার্ড পুনরুদ্ধার লিঙ্ক পাবেন।"
@@ -71,16 +73,16 @@ bn:
     registrations:
       destroyed: "বিদায়! আপনার অ্যাকাউন্ট সফলভাবে বাতিল করা হয়েছে. আশা করি শীঘ্রই আপনি আবার আসবেন।"
       edit:
-        are_you_sure: 
-        cancel_my_account: 
-        currently_waiting_confirmation_for_email: 
-        leave_blank_if_you_don_t_want_to_change_it: 
-        title: 
-        unhappy: 
-        update: 
-        we_need_your_current_password_to_confirm_your_changes: 
+        are_you_sure:
+        cancel_my_account:
+        currently_waiting_confirmation_for_email:
+        leave_blank_if_you_don_t_want_to_change_it:
+        title:
+        unhappy:
+        update:
+        we_need_your_current_password_to_confirm_your_changes:
       new:
-        sign_up: 
+        sign_up:
       signed_up: "স্বাগতম! আপনি সফলভাবে সাইন আপ করেছেন।"
       signed_up_but_inactive: "আপনি সফলভাবে সাইন আপ করেছেন। যদিও আপনার অ্যাকাউন্ট এখনো সক্রিয় না হওয়ায়, আপনি সাইন ইন করতে পারবেন না।"
       signed_up_but_locked: "আপনি সফলভাবে সাইন আপ করেছেন। যদিও আপনার অ্যাকাউন্ট লক থাকায় আপনি সাইন ইন করতে পারবেন না।"
@@ -90,21 +92,21 @@ bn:
     sessions:
       already_signed_out: "সফলভাবে সাইন আউট করেছেন।"
       new:
-        sign_in: 
+        sign_in:
       signed_in: "সফলভাবে সাইন ইন করেছেন।"
       signed_out: "সফলভাবে সাইন আউট করেছেন।"
     shared:
       links:
-        back: 
-        didn_t_receive_confirmation_instructions: 
-        didn_t_receive_unlock_instructions: 
-        forgot_your_password: 
-        sign_in: 
-        sign_in_with_provider: 
-        sign_up: 
+        back:
+        didn_t_receive_confirmation_instructions:
+        didn_t_receive_unlock_instructions:
+        forgot_your_password:
+        sign_in:
+        sign_in_with_provider:
+        sign_up:
     unlocks:
       new:
-        resend_unlock_instructions: 
+        resend_unlock_instructions:
       send_instructions: "আপনি কয়েক মিনিটের মধ্যে আপনার অ্যাকাউন্ট আনলক করার জন্যে নির্দেশাবলী সহ একটি ইমেল পাবেন।"
       send_paranoid_instructions: "আপনার অ্যাকাউন্ট উপস্থিত থাকলে, আপনি কয়েক মিনিটের মধ্যে এটি আনলক করার জন্যে নির্দেশাবলী সহ একটি ইমেল পাবেন।"
       unlocked: "আপনার অ্যাকাউন্ট সফলভাবে উদ্ঘাটিত হয়েছে। চালিয়ে যাওয়ার জন্য সাইন ইন করুন।"

--- a/rails/locales/bs.yml
+++ b/rails/locales/bs.yml
@@ -2,20 +2,24 @@ bs:
   activerecord:
     attributes:
       user:
-        current_password: 
-        email: 
-        password: 
-        password_confirmation: 
-        remember_me: 
-        reset_password_token: 
-        unlock_token: 
+        current_password:
+        email:
+        password:
+        password_confirmation:
+        remember_me:
+        reset_password_token:
+        unlock_token:
     models:
-      user: 
+      user:
+        one:
+        few:
+        many:
+        other:
   devise:
     confirmations:
       confirmed: Vaš račun je potvrđen.
       new:
-        resend_confirmation_instructions: 
+        resend_confirmation_instructions:
       send_instructions: U roku nekoliko minuta ćete primiti e-mail s uputama za potvrdu Vašeg računa.
       send_paranoid_instructions: Ukoliko se Vaša email adresa nalazi u našoj bazi u roku od nekoliko minuta ćete primiti e-mail s uputama kako potvrditi Vaš račun.
     failure:
@@ -30,39 +34,39 @@ bs:
       unconfirmed: Za nastavak morate potvrditi Vaš račun.
     mailer:
       confirmation_instructions:
-        action: 
-        greeting: 
-        instruction: 
+        action:
+        greeting:
+        instruction:
         subject: Upute za potvrdu korisničkog računa
       password_change:
-        greeting: 
-        message: 
-        subject: 
+        greeting:
+        message:
+        subject:
       reset_password_instructions:
-        action: 
-        greeting: 
-        instruction: 
-        instruction_2: 
-        instruction_3: 
+        action:
+        greeting:
+        instruction:
+        instruction_2:
+        instruction_3:
         subject: Upute za promjenu lozinke
       unlock_instructions:
-        action: 
-        greeting: 
-        instruction: 
-        message: 
+        action:
+        greeting:
+        instruction:
+        message:
         subject: Upute za otključavanje korisničkog računa
     omniauth_callbacks:
       failure: Nismo Vas u mogućnosti autorizirati sa %{kind} računom zbog "%{reason}".
       success: Uspješna autorizacija sa %{kind} računa.
     passwords:
       edit:
-        change_my_password: 
-        change_your_password: 
-        confirm_new_password: 
-        new_password: 
+        change_my_password:
+        change_your_password:
+        confirm_new_password:
+        new_password:
       new:
-        forgot_your_password: 
-        send_me_reset_password_instructions: 
+        forgot_your_password:
+        send_me_reset_password_instructions:
       no_token: Ne možete pristupiti ovoj stranici ako niste kliknuli na link u e-mailu za resetovanje lozinke.
       send_instructions: U roku nekoliko minuta ćete primiti e-mail s uputama za resetovanje Vaše lozinke.
       send_paranoid_instructions: Ukoliko se Vaša e-mail adresa nalazi u našoj bazi, u roku nekoliko minuta ćete primiti link za resetovanje lozinke.
@@ -71,16 +75,16 @@ bs:
     registrations:
       destroyed: Pozdrav! Vaš račun je uspješno obrisan. Nadamo se da ćete se brzo vratiti.
       edit:
-        are_you_sure: 
-        cancel_my_account: 
-        currently_waiting_confirmation_for_email: 
-        leave_blank_if_you_don_t_want_to_change_it: 
-        title: 
-        unhappy: 
-        update: 
-        we_need_your_current_password_to_confirm_your_changes: 
+        are_you_sure:
+        cancel_my_account:
+        currently_waiting_confirmation_for_email:
+        leave_blank_if_you_don_t_want_to_change_it:
+        title:
+        unhappy:
+        update:
+        we_need_your_current_password_to_confirm_your_changes:
       new:
-        sign_up: 
+        sign_up:
       signed_up: Dobrodošli! Uspješno ste se registrovali.
       signed_up_but_inactive: Uspješno ste se registrovali. Nažalost, ne možete se prijaviti, jer Vaš račun još nije aktiviran.
       signed_up_but_locked: Uspješno ste se registrovali. Nažalost, ne možete se prijaviti, jer Vam je račun zaključan.
@@ -88,23 +92,23 @@ bs:
       update_needs_confirmation: Uspješno ste ažurirali Vaš račun, ali trebamo potvrditi Vašu novu e-mail adresu. Molimo provjerite svoje sanduče i kliknite na link za potvrdu.
       updated: Uspješno ste izmjenili Vaš račun.
     sessions:
-      already_signed_out: 
+      already_signed_out:
       new:
-        sign_in: 
+        sign_in:
       signed_in: Uspješno ste se prijavili.
       signed_out: Uspješno ste se odjavili.
     shared:
       links:
-        back: 
-        didn_t_receive_confirmation_instructions: 
-        didn_t_receive_unlock_instructions: 
-        forgot_your_password: 
-        sign_in: 
-        sign_in_with_provider: 
-        sign_up: 
+        back:
+        didn_t_receive_confirmation_instructions:
+        didn_t_receive_unlock_instructions:
+        forgot_your_password:
+        sign_in:
+        sign_in_with_provider:
+        sign_up:
     unlocks:
       new:
-        resend_unlock_instructions: 
+        resend_unlock_instructions:
       send_instructions: U roku nekoliko minuta ćete primiti e-mail s uputama za otključavanje Vašeg računa.
       send_paranoid_instructions: Ako Vaš račun postoji, na e-mail ćete u roku nekoliko minuta primiti upute kako ga otključati.
       unlocked: Vaš račun je uspješno otključan. Molimo prijavite se.

--- a/rails/locales/ca.yml
+++ b/rails/locales/ca.yml
@@ -10,7 +10,9 @@ ca:
         reset_password_token: Restabliment de token de la contrasenya
         unlock_token: Desbloquejar el token
     models:
-      user: Usuari
+      user:
+        one: Usuari
+        other: Usuaris
   devise:
     confirmations:
       confirmed: La vostra adreça electrònica ha estat confirmada correctament.

--- a/rails/locales/cs.yml
+++ b/rails/locales/cs.yml
@@ -7,10 +7,13 @@ cs:
         password: Heslo
         password_confirmation: Potvrzení hesla
         remember_me: Zapamatuj si mě
-        reset_password_token: 
-        unlock_token: 
+        reset_password_token:
+        unlock_token:
     models:
-      user: Uživatel
+      user:
+        one: Uživatel
+        few: 
+        other: Uživatelé
   devise:
     confirmations:
       confirmed: Váš účet byl úspěšně potvrzen.
@@ -35,9 +38,9 @@ cs:
         instruction: Můžete potvrdit svůj účet pomocí odkazu níže
         subject: Instrukce k potvrzení účtu
       password_change:
-        greeting: 
-        message: 
-        subject: 
+        greeting:
+        message:
+        subject:
       reset_password_instructions:
         action: Změnit mé heslo
         greeting: Ahoj %{recipient}!

--- a/rails/locales/da.yml
+++ b/rails/locales/da.yml
@@ -7,10 +7,12 @@ da:
         password: Kodeord
         password_confirmation: Gentag kodeord
         remember_me: Husk mig
-        reset_password_token: 
-        unlock_token: 
+        reset_password_token:
+        unlock_token:
     models:
-      user: Bruger
+      user:
+        one: Bruger
+        other: Brugere
   devise:
     confirmations:
       confirmed: Din konto er aktiveret og du er nu logget ind.
@@ -36,7 +38,7 @@ da:
         subject: Bekræftelsesinstruktioner
       password_change:
         greeting: Hej %{recipient}!
-        message: 
+        message:
         subject: Kodeordet er ændret
       reset_password_instructions:
         action: Skift mit kodeord

--- a/rails/locales/de-CH.yml
+++ b/rails/locales/de-CH.yml
@@ -10,7 +10,9 @@ de-CH:
         reset_password_token: Passwort-Zurücksetzen-Token
         unlock_token: Entsperrungs-Token
     models:
-      user: Benutzer
+      user:
+        one: Benutzer
+        other: Benutzer
   devise:
     confirmations:
       confirmed: Ihre E-Mail Adresse wurde erfolgreich bestätigt.

--- a/rails/locales/de.yml
+++ b/rails/locales/de.yml
@@ -10,7 +10,9 @@ de:
         reset_password_token: Passwort-Zurücksetzen-Token
         unlock_token: Entsperrungs-Token
     models:
-      user: Benutzer
+      user:
+        one: Benutzer
+        other: Benutzer
   devise:
     confirmations:
       confirmed: Ihre E-Mail Adresse wurde erfolgreich bestätigt.

--- a/rails/locales/el.yml
+++ b/rails/locales/el.yml
@@ -7,10 +7,12 @@ el:
         password: "Κωδικός πρόσβασης"
         password_confirmation: "Επιβεβαίωση κωδικού πρόσβασης"
         remember_me: "Απομνημόνευση"
-        reset_password_token: 
-        unlock_token: 
+        reset_password_token:
+        unlock_token:
     models:
-      user: "Χρήστης"
+      user:
+        one: "Χρήστης"
+        other: "Χρήστες"
   devise:
     confirmations:
       confirmed: "Ο λογαριασμός σας επιβεβαιώθηκε επιτυχώς. Έχετε πλέον συνδεθεί."
@@ -35,9 +37,9 @@ el:
         instruction: "Μπορείτε να επιβεβαιώσετε τον λογαριασμό σας μέσω του συνδέσμου παρακάτω:"
         subject: "Οδηγίες επιβεβαίωσης"
       password_change:
-        greeting: 
-        message: 
-        subject: 
+        greeting:
+        message:
+        subject:
       reset_password_instructions:
         action: "Αλλαγή του κωδικού πρόσβασης"
         greeting: "Γεια σας %{recipient}!"

--- a/rails/locales/en-GB.yml
+++ b/rails/locales/en-GB.yml
@@ -10,7 +10,9 @@ en-GB:
         reset_password_token: Reset password token
         unlock_token: Unlock token
     models:
-      user: User
+      user:
+        one: User
+        other: Users
   devise:
     confirmations:
       confirmed: Your account was successfully confirmed.

--- a/rails/locales/en.yml
+++ b/rails/locales/en.yml
@@ -10,7 +10,9 @@ en:
         reset_password_token: Reset password token
         unlock_token: Unlock token
     models:
-      user: User
+      user:
+        one: User
+        other: Users
   devise:
     confirmations:
       confirmed: Your email address has been successfully confirmed.

--- a/rails/locales/es-MX.yml
+++ b/rails/locales/es-MX.yml
@@ -10,7 +10,9 @@ es-MX:
         reset_password_token: Restablecer autentificador de contraseña
         unlock_token: Autentificador de desbloqueo
     models:
-      user: Usuario
+      user:
+        one: Usuario
+        other: Usuarios
   devise:
     confirmations:
       confirmed: Se ha confirmado la dirección de correo electrónico correctamente.

--- a/rails/locales/es.yml
+++ b/rails/locales/es.yml
@@ -10,7 +10,9 @@ es:
         reset_password_token: Restablecer token contraseña
         unlock_token: Desbloquear token
     models:
-      user: Usuario
+      user:
+        one: Usuario
+        other: Usuarios
   devise:
     confirmations:
       confirmed: Tu cuenta ha sido confirmada satisfactoriamente.

--- a/rails/locales/et.yml
+++ b/rails/locales/et.yml
@@ -10,7 +10,9 @@ et:
         reset_password_token: Parooli ennistamise tähis
         unlock_token: Avamise tähis
     models:
-      user: Kasutaja
+      user:
+        one: Kasutaja
+        other: Kasutajad
   devise:
     confirmations:
       confirmed: Sinu konto on edukalt kinnitatud.

--- a/rails/locales/fa.yml
+++ b/rails/locales/fa.yml
@@ -10,7 +10,9 @@ fa:
         reset_password_token: 
         unlock_token: 
     models:
-      user: "کاربر"
+      user:
+        one: "کاربر"
+        other: "کاربران"
   devise:
     confirmations:
       confirmed: "حسابتان با موفقیت تایید شد. هم اکنون وارد شدید."

--- a/rails/locales/fi.yml
+++ b/rails/locales/fi.yml
@@ -10,7 +10,9 @@ fi:
         reset_password_token: Salasanan nollaamistunniste
         unlock_token: Lukituksen poistotunniste
     models:
-      user: Käyttäjä
+      user:
+        one: Käyttäjä
+        other: Käyttäjät
   devise:
     confirmations:
       confirmed: Tunnuksesi on nyt vahvistettu.

--- a/rails/locales/fr-CA.yml
+++ b/rails/locales/fr-CA.yml
@@ -7,15 +7,17 @@ fr-CA:
         password: Mot de passe
         password_confirmation: Confirmation de mot de passe
         remember_me: Se souvenir de moi
-        reset_password_token: 
-        unlock_token: 
+        reset_password_token:
+        unlock_token:
     models:
-      user: 
+      user:
+        one: Utilisateur
+        other: Utilisateurs
   devise:
     confirmations:
       confirmed: Votre compte a été confirmé avec succès.
       new:
-        resend_confirmation_instructions: 
+        resend_confirmation_instructions:
       send_instructions: Vous allez recevoir sous quelques minutes un courriel comportant des instructions pour confirmer votre compte.
       send_paranoid_instructions: Si votre courriel existe sur notre base de données, vous recevrez sous quelques minutes un message avec des instructions pour confirmer votre compte.
     failure:
@@ -30,39 +32,39 @@ fr-CA:
       unconfirmed: Vous devez confirmer votre compte par courriel.
     mailer:
       confirmation_instructions:
-        action: 
-        greeting: 
-        instruction: 
+        action:
+        greeting:
+        instruction:
         subject: Instructions de confirmation
       password_change:
-        greeting: 
-        message: 
-        subject: 
+        greeting:
+        message:
+        subject:
       reset_password_instructions:
-        action: 
-        greeting: 
-        instruction: 
-        instruction_2: 
-        instruction_3: 
+        action:
+        greeting:
+        instruction:
+        instruction_2:
+        instruction_3:
         subject: Instructions pour changer le mot de passe
       unlock_instructions:
-        action: 
-        greeting: 
-        instruction: 
-        message: 
+        action:
+        greeting:
+        instruction:
+        message:
         subject: Instructions pour déverrouiller le compte
     omniauth_callbacks:
       failure: 'Nous ne pouvons pas vous authentifier depuis %{kind} pour la raison suivante : ''%{reason}''.'
       success: Autorisé avec succès par votre compte %{kind}.
     passwords:
       edit:
-        change_my_password: 
-        change_your_password: 
-        confirm_new_password: 
-        new_password: 
+        change_my_password:
+        change_your_password:
+        confirm_new_password:
+        new_password:
       new:
-        forgot_your_password: 
-        send_me_reset_password_instructions: 
+        forgot_your_password:
+        send_me_reset_password_instructions:
       no_token: Vous ne pouvez pas accéder à cette page si vous n’y accédez pas depuis un courriel de réinitialisation de mot de passe. Si vous venez en effet d’un tel courriel, vérifiez que vous avez copié l’adresse URL en entier.
       send_instructions: Vous allez recevoir sous quelques minutes un courriel vous indiquant comment réinitialiser votre mot de passe.
       send_paranoid_instructions: Si votre courriel existe dans notre base de données, vous recevrez un lien vous permettant de récupérer votre mot de passe.
@@ -71,16 +73,16 @@ fr-CA:
     registrations:
       destroyed: Au revoir ! Votre compte a été annulé avec succès. Nous espérons vous revoir bientôt.
       edit:
-        are_you_sure: 
-        cancel_my_account: 
-        currently_waiting_confirmation_for_email: 
-        leave_blank_if_you_don_t_want_to_change_it: 
-        title: 
-        unhappy: 
-        update: 
-        we_need_your_current_password_to_confirm_your_changes: 
+        are_you_sure:
+        cancel_my_account:
+        currently_waiting_confirmation_for_email:
+        leave_blank_if_you_don_t_want_to_change_it:
+        title:
+        unhappy:
+        update:
+        we_need_your_current_password_to_confirm_your_changes:
       new:
-        sign_up: 
+        sign_up:
       signed_up: Bienvenue ! Vous vous êtes enregistré(e) avec succès.
       signed_up_but_inactive: Vous vous êtes enregistré(e) avec succès. Cependant, nous n’avons pas pu vous connecter car votre compte n’a pas encore été activé.
       signed_up_but_locked: Vous vous êtes enregistré(e) avec succès. Cependant, nous n’avons pas pu vous connecter car votre compte est verrouillé.
@@ -90,21 +92,21 @@ fr-CA:
     sessions:
       already_signed_out: Déconnecté(e).
       new:
-        sign_in: 
+        sign_in:
       signed_in: Connecté(e) avec succès.
       signed_out: Déconnecté(e) avec succès.
     shared:
       links:
-        back: 
-        didn_t_receive_confirmation_instructions: 
-        didn_t_receive_unlock_instructions: 
-        forgot_your_password: 
-        sign_in: 
-        sign_in_with_provider: 
-        sign_up: 
+        back:
+        didn_t_receive_confirmation_instructions:
+        didn_t_receive_unlock_instructions:
+        forgot_your_password:
+        sign_in:
+        sign_in_with_provider:
+        sign_up:
     unlocks:
       new:
-        resend_unlock_instructions: 
+        resend_unlock_instructions:
       send_instructions: Vous allez recevoir sous quelques minutes un courriel comportant des instructions pour déverrouiller votre compte.
       send_paranoid_instructions: Si votre courriel existe sur notre base de données, vous recevrez sous quelques minutes un message avec des instructions pour déverrouiller votre compte.
       unlocked: Votre compte a été déverrouillé avec succès. Veuillez vous connecter.

--- a/rails/locales/fr.yml
+++ b/rails/locales/fr.yml
@@ -10,7 +10,9 @@ fr:
         reset_password_token: Clé de Réinitialisation du Mot de Passe
         unlock_token: Clé de déblocage
     models:
-      user: Utilisateur
+      user:
+        one: Utilisateur
+        other: Utilisateurs
   devise:
     confirmations:
       confirmed: Votre compte a été confirmé avec succès.

--- a/rails/locales/he.yml
+++ b/rails/locales/he.yml
@@ -10,7 +10,9 @@ he:
         reset_password_token: 
         unlock_token: 
     models:
-      user: "משתמש"
+      user: 
+        one: "משתמש"
+        other: "משתמשים"
   devise:
     confirmations:
       confirmed: "חשבונך אושר בהצלחה."

--- a/rails/locales/hr.yml
+++ b/rails/locales/hr.yml
@@ -2,20 +2,24 @@ hr:
   activerecord:
     attributes:
       user:
-        current_password: 
-        email: 
-        password: 
-        password_confirmation: 
-        remember_me: 
-        reset_password_token: 
-        unlock_token: 
+        current_password:
+        email:
+        password:
+        password_confirmation:
+        remember_me:
+        reset_password_token:
+        unlock_token:
     models:
-      user: 
+      user:
+        one:
+        few:
+        many:
+        other:
   devise:
     confirmations:
       confirmed: Vaš račun je uspješno potvrđen. Sad ste prijavljeni.
       new:
-        resend_confirmation_instructions: 
+        resend_confirmation_instructions:
       send_instructions: U roku nekoliko minuta ćete primiti e-mail s uputama za potvrdu Vašeg računa.
       send_paranoid_instructions: Ukoliko se Vaša email adresa nalazi u našoj bazi u roku od nekoliko minuta ćete primiti mail s uputama kako potvrditi Vaš račun.
     failure:
@@ -30,39 +34,39 @@ hr:
       unconfirmed: Prije nastavka morate potvrditi Vaš račun.
     mailer:
       confirmation_instructions:
-        action: 
-        greeting: 
-        instruction: 
+        action:
+        greeting:
+        instruction:
         subject: Upute za potvrdu korisničkog računa
       password_change:
-        greeting: 
-        message: 
-        subject: 
+        greeting:
+        message:
+        subject:
       reset_password_instructions:
-        action: 
-        greeting: 
-        instruction: 
-        instruction_2: 
-        instruction_3: 
+        action:
+        greeting:
+        instruction:
+        instruction_2:
+        instruction_3:
         subject: Upute za promjenu lozinke
       unlock_instructions:
-        action: 
-        greeting: 
-        instruction: 
-        message: 
+        action:
+        greeting:
+        instruction:
+        message:
         subject: Upute za otključavanje korisničkog računa
     omniauth_callbacks:
       failure: Nismo Vas u mogućnosti autorizirati sa %{kind} računom zbog "%{reason}".
       success: Uspješna autorizacija sa %{kind} računa.
     passwords:
       edit:
-        change_my_password: 
-        change_your_password: 
-        confirm_new_password: 
-        new_password: 
+        change_my_password:
+        change_your_password:
+        confirm_new_password:
+        new_password:
       new:
-        forgot_your_password: 
-        send_me_reset_password_instructions: 
+        forgot_your_password:
+        send_me_reset_password_instructions:
       no_token: Ne možete pristupiti ovoj stranici ako niste kliknuli na link u emailu za resetiranje lozinke.
       send_instructions: U roku nekoliko minuta ćete primiti e-mail s uputama za promjenu Vaše lozinke.
       send_paranoid_instructions: Ukoliko se Vaša email adresa nalazi u našoj bazi, na istu ćete u roku od nekoliko minuta primiti link za resetiranje lozinke.
@@ -71,16 +75,16 @@ hr:
     registrations:
       destroyed: Pozdrav! Vaš račun je uspješno obrisan. Nadamo se da ćete se brzo vratiti.
       edit:
-        are_you_sure: 
-        cancel_my_account: 
-        currently_waiting_confirmation_for_email: 
-        leave_blank_if_you_don_t_want_to_change_it: 
-        title: 
-        unhappy: 
-        update: 
-        we_need_your_current_password_to_confirm_your_changes: 
+        are_you_sure:
+        cancel_my_account:
+        currently_waiting_confirmation_for_email:
+        leave_blank_if_you_don_t_want_to_change_it:
+        title:
+        unhappy:
+        update:
+        we_need_your_current_password_to_confirm_your_changes:
       new:
-        sign_up: 
+        sign_up:
       signed_up: Dobrodošli! Uspješno ste se registrirali.
       signed_up_but_inactive: Uspješno ste se registrirali. Doduše, ne možete se prijaviti u sustav zato što Vaš račun još nije aktiviran.
       signed_up_but_locked: Uspješno ste se registrirali. Nažalost ne možete se prijaviti jer Vam je račun zaključan.
@@ -88,23 +92,23 @@ hr:
       update_needs_confirmation: Uspješno ste ažurirali Vaš račun, ali trebamo potvrditi Vašu novu e-mail adresu. Molimo provjerite svoje sanduče i kliknite na link za potvrdu.
       updated: Uspješno ste izmjenili Vaš račun.
     sessions:
-      already_signed_out: 
+      already_signed_out:
       new:
-        sign_in: 
+        sign_in:
       signed_in: Uspješno ste se prijavili.
       signed_out: Uspješno ste se odjavili.
     shared:
       links:
-        back: 
-        didn_t_receive_confirmation_instructions: 
-        didn_t_receive_unlock_instructions: 
-        forgot_your_password: 
-        sign_in: 
-        sign_in_with_provider: 
-        sign_up: 
+        back:
+        didn_t_receive_confirmation_instructions:
+        didn_t_receive_unlock_instructions:
+        forgot_your_password:
+        sign_in:
+        sign_in_with_provider:
+        sign_up:
     unlocks:
       new:
-        resend_unlock_instructions: 
+        resend_unlock_instructions:
       send_instructions: U roku nekoliko minuta ćete primiti e-mail s uputama za otključavanje Vašeg računa.
       send_paranoid_instructions: Ako Vaš račun postoji, na email ćete u roku nekoliko minuta primiti upute kako ga otključati.
       unlocked: Vaš račun je uspješno otključan. Molimo prijavite se.

--- a/rails/locales/hu.yml
+++ b/rails/locales/hu.yml
@@ -7,10 +7,12 @@ hu:
         password: Jelszó
         password_confirmation: Jelszó megerősítése
         remember_me: Megjegyez
-        reset_password_token: 
-        unlock_token: 
+        reset_password_token:
+        unlock_token:
     models:
-      user: Felhasználó
+      user:
+        one: Felhasználó
+        other: Felhasználók
   devise:
     confirmations:
       confirmed: Fiók megerősítve. Bejelentkezve a felhasználói fiókba.
@@ -35,9 +37,9 @@ hu:
         instruction: 'A fiók megerősítéséhez rá kell kattintani az alábbi linkre:'
         subject: Email cím megerősítés
       password_change:
-        greeting: 
-        message: 
-        subject: 
+        greeting:
+        message:
+        subject:
       reset_password_instructions:
         action: Jelszó megváltoztatása
         greeting: Kedves %{recipient}!

--- a/rails/locales/id.yml
+++ b/rails/locales/id.yml
@@ -7,10 +7,12 @@ id:
         password: Password
         password_confirmation: Konfirmasi password
         remember_me: Ingat saya
-        reset_password_token: 
-        unlock_token: 
+        reset_password_token:
+        unlock_token:
     models:
-      user: User
+      user:
+        one: Pemakai
+        other: Pengguna
   devise:
     confirmations:
       confirmed: Akun anda telah berhasil dikonfirmasi. Anda telah sign in.
@@ -88,7 +90,7 @@ id:
       update_needs_confirmation: Berhasil memperbarui akun, namun Anda harus mengonfirmasi alamat email baru. Tolong cek email anda dan klik tautan konfirmasi untuk menyelesaikan konfirmasi email baru Anda.
       updated: Akun anda telah berhasil diperbaharui.
     sessions:
-      already_signed_out: 
+      already_signed_out:
       new:
         sign_in: Masuk
       signed_in: Proses sign in berhasil.

--- a/rails/locales/is.yml
+++ b/rails/locales/is.yml
@@ -2,68 +2,70 @@ is:
   activerecord:
     attributes:
       user:
-        current_password: 
-        email: 
-        password: 
-        password_confirmation: 
-        remember_me: 
-        reset_password_token: 
-        unlock_token: 
+        current_password:
+        email:
+        password:
+        password_confirmation:
+        remember_me:
+        reset_password_token:
+        unlock_token:
     models:
-      user: 
+      user:
+        one:
+        other:
   devise:
     confirmations:
       confirmed: Aðgangurinn hefur verið staðfestur. Þú ert núna innskráð(ur).
       new:
-        resend_confirmation_instructions: 
+        resend_confirmation_instructions:
       send_instructions: Eftir nokkrar mínútur munt þú fá tölvupóst með leiðbeiningum um hverning eigi að staðfesta aðganginn.
       send_paranoid_instructions: Ef netfangið þitt er til í gagnagrunninum okkar munt þú fá leiðbeiningar um hvernig eigi að staðfesta aðganginn sendar tölvupósti innan nokkurra mínútna.
     failure:
       already_authenticated: "Þú ert nú þegar innskráð(ur)."
       inactive: Aðgangurinn þinn hefur ekki verið staðfestur.
       invalid: "Ógilt notandanafn eða lykilorð."
-      last_attempt: 
+      last_attempt:
       locked: Aðgangurinn þinn er læstur.
-      not_found_in_database: 
+      not_found_in_database:
       timeout: Seta þín hefur runnið út, skráðu þig aftur inn til að halda áfram.
       unauthenticated: "Þú þarft að vera innskráð(ur) til þess að halda áfram."
       unconfirmed: "Þú verður að staðfesta aðganginn þinn áður en þú getur haldið áfram."
     mailer:
       confirmation_instructions:
-        action: 
-        greeting: 
-        instruction: 
+        action:
+        greeting:
+        instruction:
         subject: Staðfestingarleiðbeiningar
       password_change:
-        greeting: 
-        message: 
-        subject: 
+        greeting:
+        message:
+        subject:
       reset_password_instructions:
-        action: 
-        greeting: 
-        instruction: 
-        instruction_2: 
-        instruction_3: 
+        action:
+        greeting:
+        instruction:
+        instruction_2:
+        instruction_3:
         subject: Leiðbeiningar um endurstillingu lykilorðs
       unlock_instructions:
-        action: 
-        greeting: 
-        instruction: 
-        message: 
+        action:
+        greeting:
+        instruction:
+        message:
         subject: Aflæsingarleiðbeiningar
     omniauth_callbacks:
       failure: 'Innskráning með %{kind} aðgangi mistókst: %{reason}.'
       success: Innskráning með %{kind} aðgangi tókst.
     passwords:
       edit:
-        change_my_password: 
-        change_your_password: 
-        confirm_new_password: 
-        new_password: 
+        change_my_password:
+        change_your_password:
+        confirm_new_password:
+        new_password:
       new:
-        forgot_your_password: 
-        send_me_reset_password_instructions: 
-      no_token: 
+        forgot_your_password:
+        send_me_reset_password_instructions:
+      no_token:
       send_instructions: Innan nokkra mínútna færðu tölvupóst með leiðbeiningum um hvernig hægt sé að endurstilla aðganginn þinn.
       send_paranoid_instructions: Ef netfangið þitt er til í gagnagrunninum okkar munt þú fá leiðbeiningar um endurstillingu sendar í tölvupósti innan nokkra mínútna.
       updated: Lykilorði þínu hefur nú verið breytt. Þú ert núna innskráð(ur).
@@ -71,16 +73,16 @@ is:
     registrations:
       destroyed: Bless! Aðgangnum þínum hefur verið lokað. Vonandi sjáumst við aftur.
       edit:
-        are_you_sure: 
-        cancel_my_account: 
-        currently_waiting_confirmation_for_email: 
-        leave_blank_if_you_don_t_want_to_change_it: 
-        title: 
-        unhappy: 
-        update: 
-        we_need_your_current_password_to_confirm_your_changes: 
+        are_you_sure:
+        cancel_my_account:
+        currently_waiting_confirmation_for_email:
+        leave_blank_if_you_don_t_want_to_change_it:
+        title:
+        unhappy:
+        update:
+        we_need_your_current_password_to_confirm_your_changes:
       new:
-        sign_up: 
+        sign_up:
       signed_up: Velkomin(n)! Þú hefur nýskráð þig.
       signed_up_but_inactive: "Þú hefur nýskráð þig. Hins vegar gátum við ekki innskráð þig því að aðgangurinn þinn hefur ekki verið virktur."
       signed_up_but_locked: "Þú hefur nýskráð þig. Hins vegar gátum við ekki innskráð þig því að aðgangurinn þinn er læstur."
@@ -88,30 +90,30 @@ is:
       update_needs_confirmation: Aðgangurinn þinn hefur verið uppfærður, en þú þarft að staðfesta netfangið þitt. Vinsamlegast skoðaðu tölvupóstinn þinn og smelltu á staðfestingartengilinn til þess að staðfesta netfangið.
       updated: Aðgangurinn þinn hefur verið uppfærður.
     sessions:
-      already_signed_out: 
+      already_signed_out:
       new:
-        sign_in: 
+        sign_in:
       signed_in: Innskráning tókst.
       signed_out: "Útskráning tókst."
     shared:
       links:
-        back: 
-        didn_t_receive_confirmation_instructions: 
-        didn_t_receive_unlock_instructions: 
-        forgot_your_password: 
-        sign_in: 
-        sign_in_with_provider: 
-        sign_up: 
+        back:
+        didn_t_receive_confirmation_instructions:
+        didn_t_receive_unlock_instructions:
+        forgot_your_password:
+        sign_in:
+        sign_in_with_provider:
+        sign_up:
     unlocks:
       new:
-        resend_unlock_instructions: 
+        resend_unlock_instructions:
       send_instructions: Innan nokkurra mínútna færðu tölvupóst með leiðbeiningum um hvernig hægt er að aflæsa aðgangi þínum.
       send_paranoid_instructions: Ef aðgangurinn þinn er til munt þú fá leiðbeiningar um hvernig hægt er að aflæsa honum sendar í tölvupósti innan nokkurra mínútna.
       unlocked: Aðgangnum þínum hefur verið aflæst. Þú ert innskráð(ur).
   errors:
     messages:
       already_confirmed: var nú þegar staðfestur, prófaðu að skrá þig inn
-      confirmation_period_expired: 
+      confirmation_period_expired:
       expired: hefur runnið út, vinsamlegast biðjið um nýtt
       not_found: fannst ekki
       not_locked: var ekki læstur

--- a/rails/locales/it.yml
+++ b/rails/locales/it.yml
@@ -10,7 +10,9 @@ it:
         reset_password_token: Token di reset password
         unlock_token: Token di sblocco
     models:
-      user: Utente
+      user:
+        one: Utente
+        other: Utenti
   devise:
     confirmations:
       confirmed: Il tuo account è stato correttamente confermato.

--- a/rails/locales/ja.yml
+++ b/rails/locales/ja.yml
@@ -10,7 +10,9 @@ ja:
         reset_password_token: 
         unlock_token: 
     models:
-      user: "ユーザ"
+      user: 
+        one: "ユーザ"
+        other: "ユーザー"
   devise:
     confirmations:
       confirmed: "アカウントを登録しました。"

--- a/rails/locales/ka.yml
+++ b/rails/locales/ka.yml
@@ -10,8 +10,9 @@ ka:
         reset_password_token: "პაროლის მარკერის გადატვირთვა"
         unlock_token: "მარკერის გახსნა"
     models:
-      user: |
-        მომხმარებელი
+      user:
+        one: მომხმარებელი
+        other: მომხმარებელი
   devise:
     confirmations:
       confirmed: "თქვენი ელ-ფოსტა წარმატებულად დადასტურდა."

--- a/rails/locales/ko.yml
+++ b/rails/locales/ko.yml
@@ -7,10 +7,12 @@ ko:
         password: "비밀번호"
         password_confirmation: "비밀번호 확인"
         remember_me: "로그인 정보 기억하기"
-        reset_password_token: 
-        unlock_token: 
+        reset_password_token:
+        unlock_token:
     models:
-      user: "사용자"
+      user:
+        one: "사용자"
+        other: "사용자"
   devise:
     confirmations:
       confirmed: "이메일 주소가 성공적으로 인증되었습니다."
@@ -35,9 +37,9 @@ ko:
         instruction: "아래의 링크를 클릭하시면 이메일 인증이 완료됩니다:"
         subject: "이메일 인증 안내"
       password_change:
-        greeting: 
-        message: 
-        subject: 
+        greeting:
+        message:
+        subject:
       reset_password_instructions:
         action: "비밀번호 변경"
         greeting: "%{recipient}님 안녕하세요!"

--- a/rails/locales/lt.yml
+++ b/rails/locales/lt.yml
@@ -2,20 +2,23 @@ lt:
   activerecord:
     attributes:
       user:
-        current_password: 
-        email: 
-        password: 
-        password_confirmation: 
-        remember_me: 
-        reset_password_token: 
-        unlock_token: 
+        current_password:
+        email:
+        password:
+        password_confirmation:
+        remember_me:
+        reset_password_token:
+        unlock_token:
     models:
-      user: 
+      user:
+        one:
+        few:
+        other:
   devise:
     confirmations:
       confirmed: Jūsų e-pašto adresas sėkmingai patvirtintas.
       new:
-        resend_confirmation_instructions: 
+        resend_confirmation_instructions:
       send_instructions: Už keleto minučių sulauksite elektroninio laiško su instrukcijomis kaip patvirtinti jūsų vartotojo paskyrą.
       send_paranoid_instructions: Jei esatę prisiregistravę šiuo e-pašto adresu, už keleto minučių sulauksite elektroninio laiško su instrukcijomis kaip patvirtinti jūsų vartotojo paskyrą
     failure:
@@ -30,39 +33,39 @@ lt:
       unconfirmed: Būtina patvirtinti e-pašto adresą prieš tęsiant.
     mailer:
       confirmation_instructions:
-        action: 
-        greeting: 
-        instruction: 
+        action:
+        greeting:
+        instruction:
         subject: Paskyros patvirtinimo instrukcijos
       password_change:
-        greeting: 
-        message: 
-        subject: 
+        greeting:
+        message:
+        subject:
       reset_password_instructions:
-        action: 
-        greeting: 
-        instruction: 
-        instruction_2: 
-        instruction_3: 
+        action:
+        greeting:
+        instruction:
+        instruction_2:
+        instruction_3:
         subject: Slaptažodžio keitimo instrukcijos
       unlock_instructions:
-        action: 
-        greeting: 
-        instruction: 
-        message: 
+        action:
+        greeting:
+        instruction:
+        message:
         subject: Paskyros atblokavimo instrukcijos
     omniauth_callbacks:
       failure: 'Nepavyko autentikaciją per %{kind}, klaida: "%{reason}".'
       success: Sėkmingai prisijungėte su savo %{kind} paskyra.
     passwords:
       edit:
-        change_my_password: 
-        change_your_password: 
-        confirm_new_password: 
-        new_password: 
+        change_my_password:
+        change_your_password:
+        confirm_new_password:
+        new_password:
       new:
-        forgot_your_password: 
-        send_me_reset_password_instructions: 
+        forgot_your_password:
+        send_me_reset_password_instructions:
       no_token: Jūs negalite pasiekti šio puslapio tiesiogiai, tą turite padaryti iš slaptažodžio keitimo laiško. Jei jūs atėjote naudodami nuorodą, pateiktą slaptažodžio keitimo laiške, įsitikinkite, kad nukopijavote ją visą.
       send_instructions: Jūs gausite el. laišką su slaptažodžio pakeitimo instrukcijomis netrukus.
       send_paranoid_instructions: Jei prisiregistravote šiuo e-pašto adresu, netrukus gausite el. laišką su slaptažodžio pakeitimo instrukcijomis.
@@ -71,16 +74,16 @@ lt:
     registrations:
       destroyed: Iki! Jūsų paskyra dabar yra panaikinta. Tikimės, kad ateityje sugrįšite.
       edit:
-        are_you_sure: 
-        cancel_my_account: 
-        currently_waiting_confirmation_for_email: 
-        leave_blank_if_you_don_t_want_to_change_it: 
-        title: 
-        unhappy: 
-        update: 
-        we_need_your_current_password_to_confirm_your_changes: 
+        are_you_sure:
+        cancel_my_account:
+        currently_waiting_confirmation_for_email:
+        leave_blank_if_you_don_t_want_to_change_it:
+        title:
+        unhappy:
+        update:
+        we_need_your_current_password_to_confirm_your_changes:
       new:
-        sign_up: 
+        sign_up:
       signed_up: Sveiki, jūs sėkmingai prisiregistravote.
       signed_up_but_inactive: Jūs sėkmingai prisiregistravote. Deja dar negalime jūsų prijungti, nes jūsų paskyra nėra aktyvuota.
       signed_up_but_locked: Jūs sėkmingai prisiregistravote. Deja dar negalime jūsų prijungti, nes jūsų paskyra laikinai užblokuota.
@@ -90,21 +93,21 @@ lt:
     sessions:
       already_signed_out: Jau esate atsijungę.
       new:
-        sign_in: 
+        sign_in:
       signed_in: Jūs prisijungėte.
       signed_out: Sėkmingai atsijungėte iš savo paskyros.
     shared:
       links:
-        back: 
-        didn_t_receive_confirmation_instructions: 
-        didn_t_receive_unlock_instructions: 
-        forgot_your_password: 
-        sign_in: 
-        sign_in_with_provider: 
-        sign_up: 
+        back:
+        didn_t_receive_confirmation_instructions:
+        didn_t_receive_unlock_instructions:
+        forgot_your_password:
+        sign_in:
+        sign_in_with_provider:
+        sign_up:
     unlocks:
       new:
-        resend_unlock_instructions: 
+        resend_unlock_instructions:
       send_instructions: Netrukus sulauksite el. laiško su instrukcijomis, kaip atblokuoti paskyrą.
       send_paranoid_instructions: Jei registracijai naudojote šį e-pašto adresą, netrukus sulauksite el. laiško su instrukcijomis, kaip atblokuoti paskyrą.
       unlocked: Jūsų paskyra atblokuota. Prisijunkite prie paskyros darbui tęsti.

--- a/rails/locales/lv.yml
+++ b/rails/locales/lv.yml
@@ -7,10 +7,13 @@ lv:
         password: Parole
         password_confirmation: Apstiprināt paroli
         remember_me: Atcerēties mani
-        reset_password_token: 
-        unlock_token: 
+        reset_password_token:
+        unlock_token:
     models:
-      user: Lietotājs
+      user:
+        zero: 
+        one: Lietotājs
+        other: Lietotāji
   devise:
     confirmations:
       confirmed: Jūsu lietotājs ir veiksmīgi apstiprināts. Jūs esat pieslēdzies.
@@ -35,9 +38,9 @@ lv:
         instruction: 'Jūs varat apstiprināt, Jūsu konta epastu caur saiti zemāk:'
         subject: Apstiprināšanas apraksts
       password_change:
-        greeting: 
-        message: 
-        subject: 
+        greeting:
+        message:
+        subject:
       reset_password_instructions:
         action: Veikt paroles maiņu
         greeting: Sveicināti, %{recipient}!

--- a/rails/locales/my.yml
+++ b/rails/locales/my.yml
@@ -2,117 +2,120 @@ my:
   activerecord:
     attributes:
       user:
-        current_password: 
-        email: 
-        password: 
-        password_confirmation: 
-        remember_me: 
-        reset_password_token: 
-        unlock_token: 
+        current_password:
+        email:
+        password:
+        password_confirmation:
+        remember_me:
+        reset_password_token:
+        unlock_token:
     models:
-      user: 
+      user:
+        one:
+        few:
+        other:
   devise:
     confirmations:
       confirmed: Akaun anda telah berjaya disahkan. Anda telah sign in.
       new:
-        resend_confirmation_instructions: 
+        resend_confirmation_instructions:
       send_instructions: Anda akan menerima e-mail mengenai langkah proses pengesahan akaun sebentar lagi.
-      send_paranoid_instructions: 
+      send_paranoid_instructions:
     failure:
-      already_authenticated: 
+      already_authenticated:
       inactive: Akun anda belum diaktifkan.
       invalid: email atau password yang anda masukkan salah.
-      last_attempt: 
+      last_attempt:
       locked: Akun anda terkunci.
-      not_found_in_database: 
+      not_found_in_database:
       timeout: Sesi anda telah tamat, silahkan sign in bagi meneruskan sesi yang baru.
       unauthenticated: Anda harus mendaftar atau sign in sebelum meneruskan .
       unconfirmed: Anda harus melakukan proses pengesahan sebalum meneruskan.
     mailer:
       confirmation_instructions:
-        action: 
-        greeting: 
-        instruction: 
+        action:
+        greeting:
+        instruction:
         subject: Arahan proses pengesahan
       password_change:
-        greeting: 
-        message: 
-        subject: 
+        greeting:
+        message:
+        subject:
       reset_password_instructions:
-        action: 
-        greeting: 
-        instruction: 
-        instruction_2: 
-        instruction_3: 
+        action:
+        greeting:
+        instruction:
+        instruction_2:
+        instruction_3:
         subject: Arahan mengubah password
       unlock_instructions:
-        action: 
-        greeting: 
-        instruction: 
-        message: 
+        action:
+        greeting:
+        instruction:
+        message:
         subject: Arahan membuka akaun kembali
     omniauth_callbacks:
-      failure: 
-      success: 
+      failure:
+      success:
     passwords:
       edit:
-        change_my_password: 
-        change_your_password: 
-        confirm_new_password: 
-        new_password: 
+        change_my_password:
+        change_your_password:
+        confirm_new_password:
+        new_password:
       new:
-        forgot_your_password: 
-        send_me_reset_password_instructions: 
-      no_token: 
+        forgot_your_password:
+        send_me_reset_password_instructions:
+      no_token:
       send_instructions: Anda akan menerima e-mail mengenai langkah mengubah password sebentar lagi.
-      send_paranoid_instructions: 
+      send_paranoid_instructions:
       updated: Password anda telah berjaya diubah. Anda telah sign in.
-      updated_not_active: 
+      updated_not_active:
     registrations:
       destroyed: Selamat Tinggal, akaun anda telah di tutup
       edit:
-        are_you_sure: 
-        cancel_my_account: 
-        currently_waiting_confirmation_for_email: 
-        leave_blank_if_you_don_t_want_to_change_it: 
-        title: 
-        unhappy: 
-        update: 
-        we_need_your_current_password_to_confirm_your_changes: 
+        are_you_sure:
+        cancel_my_account:
+        currently_waiting_confirmation_for_email:
+        leave_blank_if_you_don_t_want_to_change_it:
+        title:
+        unhappy:
+        update:
+        we_need_your_current_password_to_confirm_your_changes:
       new:
-        sign_up: 
+        sign_up:
       signed_up: Proses pendaftaran berjaya. Link untuk mengaktifkan akaun telah dihantar di e-mail.
-      signed_up_but_inactive: 
-      signed_up_but_locked: 
-      signed_up_but_unconfirmed: 
-      update_needs_confirmation: 
+      signed_up_but_inactive:
+      signed_up_but_locked:
+      signed_up_but_unconfirmed:
+      update_needs_confirmation:
       updated: Akaun anda telah dikemaskini
     sessions:
-      already_signed_out: 
+      already_signed_out:
       new:
-        sign_in: 
+        sign_in:
       signed_in: Proses sign in berjaya.
       signed_out: Proses sign out berjaya.
     shared:
       links:
-        back: 
-        didn_t_receive_confirmation_instructions: 
-        didn_t_receive_unlock_instructions: 
-        forgot_your_password: 
-        sign_in: 
-        sign_in_with_provider: 
-        sign_up: 
+        back:
+        didn_t_receive_confirmation_instructions:
+        didn_t_receive_unlock_instructions:
+        forgot_your_password:
+        sign_in:
+        sign_in_with_provider:
+        sign_up:
     unlocks:
       new:
-        resend_unlock_instructions: 
+        resend_unlock_instructions:
       send_instructions: Anda akan menerima e-mail mengenai langkah membuka akaun kembali sebentar lagi.
-      send_paranoid_instructions: 
+      send_paranoid_instructions:
       unlocked: Akun anda telah berjaya dibuka. Anda telah sign in.
   errors:
     messages:
       already_confirmed: sudah disahkan
-      confirmation_period_expired: 
-      expired: 
+      confirmation_period_expired:
+      expired:
       not_found: tidak dijumpai
       not_locked: tidak dikunci
-      not_saved: 
+      not_saved:

--- a/rails/locales/nb.yml
+++ b/rails/locales/nb.yml
@@ -10,7 +10,9 @@ nb:
         reset_password_token: Nytt passord-kode
         unlock_token: Lås opp-kode
     models:
-      user: Brukerkonto
+      user:
+        one: Brukerkonto
+        other: Brukerkontoer
   devise:
     confirmations:
       confirmed: Din konto har blitt aktivert og du er nå logget inn
@@ -95,7 +97,7 @@ nb:
       signed_out: Du er nå logget ut.
     shared:
       links:
-        back: 
+        back:
         didn_t_receive_confirmation_instructions: Har du ikke mottatt bekreftelsesinstruksjoner?
         didn_t_receive_unlock_instructions: Har du ikke mottatt instruksjoner for å tilbakestille passordet?
         forgot_your_password: Har du glemt passordet ditt?

--- a/rails/locales/nl.yml
+++ b/rails/locales/nl.yml
@@ -10,7 +10,9 @@ nl:
         reset_password_token: Reset wachtwoord token
         unlock_token: Ontgrendel token
     models:
-      user: Gebruiker
+      user:
+        one: Gebruiker
+        other: Gebruikers
   devise:
     confirmations:
       confirmed: Je account is bevestigd.

--- a/rails/locales/nn-NO.yml
+++ b/rails/locales/nn-NO.yml
@@ -10,7 +10,9 @@ nn-NO:
         reset_password_token: Nullstill passord-nøkkel
         unlock_token: Lås opp nøkkel
     models:
-      user: Brukar
+      user:
+        one: Brukar
+        other: Brukere
   devise:
     confirmations:
       confirmed: E-postadressen din har blitt stadfesta.

--- a/rails/locales/no.yml
+++ b/rails/locales/no.yml
@@ -2,20 +2,22 @@
   activerecord:
     attributes:
       user:
-        current_password: 
-        email: 
-        password: 
-        password_confirmation: 
-        remember_me: 
-        reset_password_token: 
-        unlock_token: 
+        current_password:
+        email:
+        password:
+        password_confirmation:
+        remember_me:
+        reset_password_token:
+        unlock_token:
     models:
-      user: 
+      user:
+        one:
+        other: 
   devise:
     confirmations:
       confirmed: Din konto er aktivert og du er nå innlogget.
       new:
-        resend_confirmation_instructions: 
+        resend_confirmation_instructions:
       send_instructions: Du vil innen få minutter motta en epost med instruksjoner for å aktivere din konto.
       send_paranoid_instructions: Hvis epostadressen din finnes i vår database vil du innen få minutter motta en epost med instruksjoner for å aktivere din konto.
     failure:
@@ -30,39 +32,39 @@
       unconfirmed: Du må bekrefte kontoen din for å kunne fortsette.
     mailer:
       confirmation_instructions:
-        action: 
-        greeting: 
-        instruction: 
+        action:
+        greeting:
+        instruction:
         subject: Bekreftelsesinstruksjoner
       password_change:
-        greeting: 
-        message: 
-        subject: 
+        greeting:
+        message:
+        subject:
       reset_password_instructions:
-        action: 
-        greeting: 
-        instruction: 
-        instruction_2: 
-        instruction_3: 
+        action:
+        greeting:
+        instruction:
+        instruction_2:
+        instruction_3:
         subject: Nullstilling av passord
       unlock_instructions:
-        action: 
-        greeting: 
-        instruction: 
-        message: 
+        action:
+        greeting:
+        instruction:
+        message:
         subject: Gjenåpning av konto
     omniauth_callbacks:
       failure: Kunne ikke autorisere deg fra %{kind} fordi "%{reason}".
       success: Vellykket autorisering fra %{kind}.
     passwords:
       edit:
-        change_my_password: 
-        change_your_password: 
-        confirm_new_password: 
-        new_password: 
+        change_my_password:
+        change_your_password:
+        confirm_new_password:
+        new_password:
       new:
-        forgot_your_password: 
-        send_me_reset_password_instructions: 
+        forgot_your_password:
+        send_me_reset_password_instructions:
       no_token: Du kan ikke aksessere denne siden uten å bli videresendt fra en epost med intrukssjoner for å tilbakestille passord. Hvis dette er tilfelle, vennligst sørg for at du brukte hele lenken inneholdt i eposten.
       send_instructions: Du vil innen få minutter motta en epost med instruksjoner for å nullstille passordet ditt.
       send_paranoid_instructions: Hvis epostadressen din finnes i vår database vil du innen få minutter motta en epost med instruksjoner for å nullstille passordet ditt.
@@ -71,16 +73,16 @@
     registrations:
       destroyed: Farvel! Din konto er nå slettet. Vi håper å se deg igjen snart.
       edit:
-        are_you_sure: 
-        cancel_my_account: 
-        currently_waiting_confirmation_for_email: 
-        leave_blank_if_you_don_t_want_to_change_it: 
-        title: 
-        unhappy: 
-        update: 
-        we_need_your_current_password_to_confirm_your_changes: 
+        are_you_sure:
+        cancel_my_account:
+        currently_waiting_confirmation_for_email:
+        leave_blank_if_you_don_t_want_to_change_it:
+        title:
+        unhappy:
+        update:
+        we_need_your_current_password_to_confirm_your_changes:
       new:
-        sign_up: 
+        sign_up:
       signed_up: Velkommen! Din registrering er vellykket.
       signed_up_but_inactive: Du er registrert. Vi kan derimot ikke logge deg på siden kontoen din ennå ikke er aktivert.
       signed_up_but_locked: Du er registrert. Vi kan derimot ikke logge deg på siden kontoen din er låst.
@@ -88,23 +90,23 @@
       update_needs_confirmation: Din profil er oppdatert, men vi trenger å bekrefte din nye epost-adresse. Vennligst sjekk din innboks og klikk på lenken inneholdt i eposten for å bekrefte endring av din epost-adresse.
       updated: Din profil er oppdatert.
     sessions:
-      already_signed_out: 
+      already_signed_out:
       new:
-        sign_in: 
+        sign_in:
       signed_in: Du er nå innlogget.
       signed_out: Du er nå logget ut.
     shared:
       links:
-        back: 
-        didn_t_receive_confirmation_instructions: 
-        didn_t_receive_unlock_instructions: 
-        forgot_your_password: 
-        sign_in: 
-        sign_in_with_provider: 
-        sign_up: 
+        back:
+        didn_t_receive_confirmation_instructions:
+        didn_t_receive_unlock_instructions:
+        forgot_your_password:
+        sign_in:
+        sign_in_with_provider:
+        sign_up:
     unlocks:
       new:
-        resend_unlock_instructions: 
+        resend_unlock_instructions:
       send_instructions: Du vil innen få minutter motta en epost med instruksjoner for å gjenåpne din konto.
       send_paranoid_instructions: Hvis kontoen din eksisterer vil du innen få minutter motta en epost med instruksjoner for å låse den opp.
       unlocked: Din konto er gjenåpnet. Vennligst logg inn for å fortsette.

--- a/rails/locales/pl.yml
+++ b/rails/locales/pl.yml
@@ -7,10 +7,13 @@ pl:
         password: Hasło
         password_confirmation: Potwierdzenie hasła
         remember_me: Zapamiętaj mnie
-        reset_password_token: 
-        unlock_token: 
+        reset_password_token:
+        unlock_token:
     models:
-      user: Użytkownik
+      user:
+        one: Użytkownik
+        few:
+        other: Użytkownicy
   devise:
     confirmations:
       confirmed: Konto zostało poprawnie aktywowane.

--- a/rails/locales/pt-BR.yml
+++ b/rails/locales/pt-BR.yml
@@ -10,7 +10,9 @@ pt-BR:
         reset_password_token: Resetar token de senha
         unlock_token: Token de desbloqueio
     models:
-      user: Usuário
+      user:
+        one: Usuário
+        other: Usuários
   devise:
     confirmations:
       confirmed: A sua conta foi confirmada com sucesso.

--- a/rails/locales/pt.yml
+++ b/rails/locales/pt.yml
@@ -2,15 +2,17 @@ pt:
   activerecord:
     attributes:
       user:
-        current_password: 
-        email: 
-        password: 
-        password_confirmation: 
+        current_password:
+        email:
+        password:
+        password_confirmation:
         remember_me: Lembrar-se de mim
-        reset_password_token: 
-        unlock_token: 
+        reset_password_token:
+        unlock_token:
     models:
-      user: 
+      user:
+        one: Usuário
+        other: Usuários
   devise:
     confirmations:
       confirmed: A sua conta foi confirmada com sucesso.
@@ -35,9 +37,9 @@ pt:
         instruction: 'Pode confirmar a sua conta através do link:'
         subject: Instruções de confirmação
       password_change:
-        greeting: 
-        message: 
-        subject: 
+        greeting:
+        message:
+        subject:
       reset_password_instructions:
         action: Repor a minha senha
         greeting: Olá %{recipient}!
@@ -56,10 +58,10 @@ pt:
       success: A sua conta foi autenticada por %{kind} com sucesso.
     passwords:
       edit:
-        change_my_password: 
-        change_your_password: 
-        confirm_new_password: 
-        new_password: 
+        change_my_password:
+        change_your_password:
+        confirm_new_password:
+        new_password:
       new:
         forgot_your_password: Esqueceu a sua senha?
         send_me_reset_password_instructions: Enviar-me instruções para repor a senha
@@ -73,11 +75,11 @@ pt:
       edit:
         are_you_sure: Tem a certeza?
         cancel_my_account: Cancelar a minha conta
-        currently_waiting_confirmation_for_email: 
+        currently_waiting_confirmation_for_email:
         leave_blank_if_you_don_t_want_to_change_it: deixe em branco caso não queira alterar
         title: Editar %{resource}
-        unhappy: 
-        update: 
+        unhappy:
+        update:
         we_need_your_current_password_to_confirm_your_changes: precisamos da sua senha actual para confirmar as alterações
       new:
         sign_up: Criar Conta
@@ -95,7 +97,7 @@ pt:
       signed_out: Saiu da sessão com sucesso.
     shared:
       links:
-        back: 
+        back:
         didn_t_receive_confirmation_instructions: Não recebeu instruções de confirmação?
         didn_t_receive_unlock_instructions: Não recebeu instruções de desbloqueio?
         forgot_your_password: Esqueceu a palavra-passe?

--- a/rails/locales/ro.yml
+++ b/rails/locales/ro.yml
@@ -10,7 +10,10 @@ ro:
         reset_password_token: Resetează jetonul parolei
         unlock_token: Deblochează jetonul
     models:
-      user: Utilizator
+      user:
+        one: Utilizator
+        few:
+        other: Utilizatori
   devise:
     confirmations:
       confirmed: Contul dvs. a fost confirmat cu succes.

--- a/rails/locales/ru.yml
+++ b/rails/locales/ru.yml
@@ -10,7 +10,11 @@ ru:
         reset_password_token: "Ссылка сброса пароля"
         unlock_token: "Токен разблокировки"
     models:
-      user: "Пользователь"
+      user:
+        one: "Пользователь"
+        few:
+        many:
+        other: "Пользователи"
   devise:
     confirmations:
       confirmed: "Ваш адрес эл. почты успешно подтвержден."

--- a/rails/locales/sk.yml
+++ b/rails/locales/sk.yml
@@ -7,10 +7,13 @@ sk:
         password: Heslo
         password_confirmation: Potvrdenie hesla
         remember_me: Zapamätať si ma
-        reset_password_token: 
-        unlock_token: 
+        reset_password_token:
+        unlock_token:
     models:
-      user: Používateľ
+      user:
+        one: Používateľ
+        few:
+        other: Používatelia
   devise:
     confirmations:
       confirmed: Váš účet bol úspešne overený. Teraz ste prihlásený.
@@ -35,9 +38,9 @@ sk:
         instruction: 'Môžete potvrdiť emailovú adresu vášho účtu pomocou odkazu nižšie:'
         subject: Potvrdzovacie inštrukcie
       password_change:
-        greeting: 
-        message: 
-        subject: 
+        greeting:
+        message:
+        subject:
       reset_password_instructions:
         action: Zmeniť moje heslo
         greeting: Ahoj %{recipient}!

--- a/rails/locales/sl.yml
+++ b/rails/locales/sl.yml
@@ -2,20 +2,24 @@ sl:
   activerecord:
     attributes:
       user:
-        current_password: 
-        email: 
-        password: 
-        password_confirmation: 
-        remember_me: 
-        reset_password_token: 
-        unlock_token: 
+        current_password:
+        email:
+        password:
+        password_confirmation:
+        remember_me:
+        reset_password_token:
+        unlock_token:
     models:
-      user: 
+      user:
+        one:
+        two:
+        few:
+        other:
   devise:
     confirmations:
       confirmed: Vaš račun je bil uspešno potrjen. Sedaj ste prijavljeni.
       new:
-        resend_confirmation_instructions: 
+        resend_confirmation_instructions:
       send_instructions: Prejeli boste e-pošto z navodili kako potrditi vaš račun.
       send_paranoid_instructions: "Če vaša e-pošta obstaja v naši bazi, boste v naslednjih minutah prejeli e-pošto z navodili kako potrditi vaš uporabniški račun."
     failure:
@@ -30,39 +34,39 @@ sl:
       unconfirmed: Pred nadaljevanjem morate potrditi vaš račun.
     mailer:
       confirmation_instructions:
-        action: 
-        greeting: 
-        instruction: 
+        action:
+        greeting:
+        instruction:
         subject: Navodila potrditve
       password_change:
-        greeting: 
-        message: 
-        subject: 
+        greeting:
+        message:
+        subject:
       reset_password_instructions:
-        action: 
-        greeting: 
-        instruction: 
-        instruction_2: 
-        instruction_3: 
+        action:
+        greeting:
+        instruction:
+        instruction_2:
+        instruction_3:
         subject: Navodila za ponastavitev gesla
       unlock_instructions:
-        action: 
-        greeting: 
-        instruction: 
-        message: 
+        action:
+        greeting:
+        instruction:
+        message:
         subject: Navodila odklepa
     omniauth_callbacks:
       failure: Preverjanje pristnosti ni uspelo iz %{kind} zaradi "%{reason}".
       success: Uspešno preverjena pristnost iz računa %{kind}.
     passwords:
       edit:
-        change_my_password: 
-        change_your_password: 
-        confirm_new_password: 
-        new_password: 
+        change_my_password:
+        change_your_password:
+        confirm_new_password:
+        new_password:
       new:
-        forgot_your_password: 
-        send_me_reset_password_instructions: 
+        forgot_your_password:
+        send_me_reset_password_instructions:
       no_token: Do te strani lahko dostopate samo iz povezave v e-pošti za ponastavitev gesla. Če pa ste prišli do te strani preko omenjene povezave, preverite, da ste uporabili celotni URL.
       send_instructions: V naslednjih minutah boste prejeli e-pošto z navodili kako ponastaviti vaše geslo.
       send_paranoid_instructions: "Če vaša e-pošta obstaja v bazi, boste v naslednjih minutah na vašo e-pošto prejeli povezavo za obnovitev gesla."
@@ -71,16 +75,16 @@ sl:
     registrations:
       destroyed: Nasvidenje. Vaš račun je bil uspešno preklican. Upamo, da se kmalu vrnete.
       edit:
-        are_you_sure: 
-        cancel_my_account: 
-        currently_waiting_confirmation_for_email: 
-        leave_blank_if_you_don_t_want_to_change_it: 
-        title: 
-        unhappy: 
-        update: 
-        we_need_your_current_password_to_confirm_your_changes: 
+        are_you_sure:
+        cancel_my_account:
+        currently_waiting_confirmation_for_email:
+        leave_blank_if_you_don_t_want_to_change_it:
+        title:
+        unhappy:
+        update:
+        we_need_your_current_password_to_confirm_your_changes:
       new:
-        sign_up: 
+        sign_up:
       signed_up: Dobrodošli. Uspešno ste se registrirali.
       signed_up_but_inactive: Uspešno ste se registrirali, vendar pred prvo prijavo je potrebno vaš račun še aktivirati.
       signed_up_but_locked: Uspešno ste se registrirali, vendar prijava ni mogoča, ker je vaš račun zaklenjen.
@@ -88,23 +92,23 @@ sl:
       update_needs_confirmation: Vaš račun je uspešno posodobljen, vendar potrebno je preveriti vaš novi e-poštni naslov. Prosimo, preverite vašo e-pošto in kliknite na potrditveno povezavo za dokončanje potrditve vašega novega e-poštnega naslova.
       updated: Uspešno ste posodobili vaš račun.
     sessions:
-      already_signed_out: 
+      already_signed_out:
       new:
-        sign_in: 
+        sign_in:
       signed_in: Prijava je bila uspešna.
       signed_out: Odjava je bila uspešna.
     shared:
       links:
-        back: 
-        didn_t_receive_confirmation_instructions: 
-        didn_t_receive_unlock_instructions: 
-        forgot_your_password: 
-        sign_in: 
-        sign_in_with_provider: 
-        sign_up: 
+        back:
+        didn_t_receive_confirmation_instructions:
+        didn_t_receive_unlock_instructions:
+        forgot_your_password:
+        sign_in:
+        sign_in_with_provider:
+        sign_up:
     unlocks:
       new:
-        resend_unlock_instructions: 
+        resend_unlock_instructions:
       send_instructions: V naslednjih minutah boste prejeli e-pošto z navodili, kako odkleniti vaš račun.
       send_paranoid_instructions: "Če vaš račun obstaja, boste v naslednjih minutah prejeli e-pošto z navodili kako odkleniti vaš račun."
       unlocked: Vaš račun je bil uspešno odklenjen. Prosimo, prijavite se za nadaljevanje.

--- a/rails/locales/sr-RS.yml
+++ b/rails/locales/sr-RS.yml
@@ -2,20 +2,24 @@ sr-RS:
   activerecord:
     attributes:
       user:
-        current_password: 
-        email: 
-        password: 
-        password_confirmation: 
-        remember_me: 
-        reset_password_token: 
-        unlock_token: 
+        current_password:
+        email:
+        password:
+        password_confirmation:
+        remember_me:
+        reset_password_token:
+        unlock_token:
     models:
-      user: 
+      user:
+        one:
+        few:
+        many:
+        other:
   devise:
     confirmations:
       confirmed: "Ваш налог је успешно потврђен. Сада сте пријављени."
       new:
-        resend_confirmation_instructions: 
+        resend_confirmation_instructions:
       send_instructions: "У року од неколико минута примићете еПоруку са упутством за потврду Вашег налога."
       send_paranoid_instructions: "Уколико се Ваша адреса еПоште налази у нашој бази у року од неколико минута примићете еПоруку са упутством како потврдити Ваш налог."
     failure:
@@ -30,39 +34,39 @@ sr-RS:
       unconfirmed: "Пре наставка морате потврдити свој налог."
     mailer:
       confirmation_instructions:
-        action: 
-        greeting: 
-        instruction: 
+        action:
+        greeting:
+        instruction:
         subject: "Упутство за потврду корисничког налога"
       password_change:
-        greeting: 
-        message: 
-        subject: 
+        greeting:
+        message:
+        subject:
       reset_password_instructions:
-        action: 
-        greeting: 
-        instruction: 
-        instruction_2: 
-        instruction_3: 
+        action:
+        greeting:
+        instruction:
+        instruction_2:
+        instruction_3:
         subject: "Упутство за промену лозинке"
       unlock_instructions:
-        action: 
-        greeting: 
-        instruction: 
-        message: 
+        action:
+        greeting:
+        instruction:
+        message:
         subject: "Упутство за откључавање корисничког налога"
     omniauth_callbacks:
       failure: Нисмо у могућности ауторизовати Вас са %{kind} налогом због "%{reason}".
       success: "Успешна ауторизација са %{kind} налога."
     passwords:
       edit:
-        change_my_password: 
-        change_your_password: 
-        confirm_new_password: 
-        new_password: 
+        change_my_password:
+        change_your_password:
+        confirm_new_password:
+        new_password:
       new:
-        forgot_your_password: 
-        send_me_reset_password_instructions: 
+        forgot_your_password:
+        send_me_reset_password_instructions:
       no_token: "Не можете приступити овој страници ако нисте шкљоцнули на везу у еПоруци за ресетовање лозинке."
       send_instructions: "У року од неколико минута примитићете еПоруку са упутством за промену Ваше лозинке."
       send_paranoid_instructions: "Уколико се Ваша адреса еПоште налази у нашој бази, на исту ћете у року од неколико минута примити линк за ресетовање лозинке."
@@ -71,16 +75,16 @@ sr-RS:
     registrations:
       destroyed: "Поздрав! Ваш налог је успешно обрисан. Надамо се да ћете се ускоро вратити."
       edit:
-        are_you_sure: 
-        cancel_my_account: 
-        currently_waiting_confirmation_for_email: 
-        leave_blank_if_you_don_t_want_to_change_it: 
-        title: 
-        unhappy: 
-        update: 
-        we_need_your_current_password_to_confirm_your_changes: 
+        are_you_sure:
+        cancel_my_account:
+        currently_waiting_confirmation_for_email:
+        leave_blank_if_you_don_t_want_to_change_it:
+        title:
+        unhappy:
+        update:
+        we_need_your_current_password_to_confirm_your_changes:
       new:
-        sign_up: 
+        sign_up:
       signed_up: "Добродошли! Успешно сте се регистровали."
       signed_up_but_inactive: "Успешно сте се регистровали. Додуше, не можете се пријавити на систем зато што Ваш налог још није активиран."
       signed_up_but_locked: "Успешно сте се регистровали. Нажалост не можете се пријавити јер Вам је налог закључан."
@@ -88,23 +92,23 @@ sr-RS:
       update_needs_confirmation: "Успешно сте ажурирали свој налог, али требамо потврдити Вашу адресу еПоште. Проверите своје сандуче са порукама и кликните на везу за потврду."
       updated: "Успешно сте изменили свој налог."
     sessions:
-      already_signed_out: 
+      already_signed_out:
       new:
-        sign_in: 
+        sign_in:
       signed_in: "Успешно сте се пријавили."
       signed_out: "Успешно сте се одјавили."
     shared:
       links:
-        back: 
-        didn_t_receive_confirmation_instructions: 
-        didn_t_receive_unlock_instructions: 
-        forgot_your_password: 
-        sign_in: 
-        sign_in_with_provider: 
-        sign_up: 
+        back:
+        didn_t_receive_confirmation_instructions:
+        didn_t_receive_unlock_instructions:
+        forgot_your_password:
+        sign_in:
+        sign_in_with_provider:
+        sign_up:
     unlocks:
       new:
-        resend_unlock_instructions: 
+        resend_unlock_instructions:
       send_instructions: "У року од неколико минута ћете примити еПоруку са упутством за откључавање Вашег налога."
       send_paranoid_instructions: "Ако Ваш налог постоји, на адресу своје еПоште ћете у року од неколико минута примити упутство како га откључати."
       unlocked: "Ваш налог је успешно откључан. Сада се можете пријавити."

--- a/rails/locales/sr.yml
+++ b/rails/locales/sr.yml
@@ -2,20 +2,24 @@ sr:
   activerecord:
     attributes:
       user:
-        current_password: 
-        email: 
-        password: 
-        password_confirmation: 
-        remember_me: 
-        reset_password_token: 
-        unlock_token: 
+        current_password:
+        email:
+        password:
+        password_confirmation:
+        remember_me:
+        reset_password_token:
+        unlock_token:
     models:
-      user: 
+      user:
+        one:
+        few:
+        many:
+        other:
   devise:
     confirmations:
       confirmed: Vaš nalog je uspešno potvrđen. Sada ste prijavljeni.
       new:
-        resend_confirmation_instructions: 
+        resend_confirmation_instructions:
       send_instructions: U roku od nekoliko minuta primićete ePoruku sa uputstvom za potvrdu Vašeg naloga.
       send_paranoid_instructions: Ukoliko se Vaša adresa ePošte nalazi u našoj bazi u roku od nekoliko minuta primićete ePoruku sa uputstvom kako potvrditi Vaš nalog.
     failure:
@@ -30,39 +34,39 @@ sr:
       unconfirmed: Pre nastavka morate potvrditi svoj nalog.
     mailer:
       confirmation_instructions:
-        action: 
-        greeting: 
-        instruction: 
+        action:
+        greeting:
+        instruction:
         subject: Uputstvo za potvrdu korisničkog naloga
       password_change:
-        greeting: 
-        message: 
-        subject: 
+        greeting:
+        message:
+        subject:
       reset_password_instructions:
-        action: 
-        greeting: 
-        instruction: 
-        instruction_2: 
-        instruction_3: 
+        action:
+        greeting:
+        instruction:
+        instruction_2:
+        instruction_3:
         subject: Uputstvo za promenu lozinke
       unlock_instructions:
-        action: 
-        greeting: 
-        instruction: 
-        message: 
+        action:
+        greeting:
+        instruction:
+        message:
         subject: Uputstvo za otključavanje korisničkog naloga
     omniauth_callbacks:
       failure: Nismo u mogućnosti autorizovati Vas sa %{kind} nalogom zbog "%{reason}".
       success: Uspešna autorizacija sa %{kind} naloga.
     passwords:
       edit:
-        change_my_password: 
-        change_your_password: 
-        confirm_new_password: 
-        new_password: 
+        change_my_password:
+        change_your_password:
+        confirm_new_password:
+        new_password:
       new:
-        forgot_your_password: 
-        send_me_reset_password_instructions: 
+        forgot_your_password:
+        send_me_reset_password_instructions:
       no_token: Ne možete pristupiti ovoj stranici ako niste škljocnuli na vezu u ePoruci za resetovanje lozinke.
       send_instructions: U roku od nekoliko minuta primitićete ePoruku sa uputstvom za promenu Vaše lozinke.
       send_paranoid_instructions: Ukoliko se Vaša adresa ePošte nalazi u našoj bazi, na istu ćete u roku od nekoliko minuta primiti link za resetovanje lozinke.
@@ -71,16 +75,16 @@ sr:
     registrations:
       destroyed: Pozdrav! Vaš nalog je uspešno obrisan. Nadamo se da ćete se uskoro vratiti.
       edit:
-        are_you_sure: 
-        cancel_my_account: 
-        currently_waiting_confirmation_for_email: 
-        leave_blank_if_you_don_t_want_to_change_it: 
-        title: 
-        unhappy: 
-        update: 
-        we_need_your_current_password_to_confirm_your_changes: 
+        are_you_sure:
+        cancel_my_account:
+        currently_waiting_confirmation_for_email:
+        leave_blank_if_you_don_t_want_to_change_it:
+        title:
+        unhappy:
+        update:
+        we_need_your_current_password_to_confirm_your_changes:
       new:
-        sign_up: 
+        sign_up:
       signed_up: Dobrodošli! Uspešno ste se registrovali.
       signed_up_but_inactive: Uspešno ste se registrovali. Doduše, ne možete se prijaviti na sistem zato što Vaš nalog još nije aktiviran.
       signed_up_but_locked: Uspešno ste se registrovali. Nažalost ne možete se prijaviti jer Vam je nalog zaključan.
@@ -88,23 +92,23 @@ sr:
       update_needs_confirmation: Uspešno ste ažurirali svoj nalog, ali trebamo potvrditi Vašu adresu ePošte. Proverite svoje sanduče sa porukama i kliknite na vezu za potvrdu.
       updated: Uspešno ste izmenili svoj nalog.
     sessions:
-      already_signed_out: 
+      already_signed_out:
       new:
-        sign_in: 
+        sign_in:
       signed_in: Uspešno ste se prijavili.
       signed_out: Uspešno ste se odjavili.
     shared:
       links:
-        back: 
-        didn_t_receive_confirmation_instructions: 
-        didn_t_receive_unlock_instructions: 
-        forgot_your_password: 
-        sign_in: 
-        sign_in_with_provider: 
-        sign_up: 
+        back:
+        didn_t_receive_confirmation_instructions:
+        didn_t_receive_unlock_instructions:
+        forgot_your_password:
+        sign_in:
+        sign_in_with_provider:
+        sign_up:
     unlocks:
       new:
-        resend_unlock_instructions: 
+        resend_unlock_instructions:
       send_instructions: U roku od nekoliko minuta ćete primiti ePoruku sa uputstvom za otključavanje Vašeg naloga.
       send_paranoid_instructions: Ako Vaš nalog postoji, na adresu svoje ePošte ćete u roku od nekoliko minuta primiti uputstvo kako ga otključati.
       unlocked: Vaš nalog je uspešno otključan. Sada se možete prijaviti.

--- a/rails/locales/sv.yml
+++ b/rails/locales/sv.yml
@@ -10,7 +10,9 @@ sv:
         reset_password_token: "Återställ token för lösenord"
         unlock_token: Token för återaktivering
     models:
-      user: Användare
+      user:
+        one: Användare
+        other: Användare
   devise:
     confirmations:
       confirmed: Ditt konto har bekräftats. Du är nu inloggad.

--- a/rails/locales/th.yml
+++ b/rails/locales/th.yml
@@ -7,10 +7,12 @@ th:
         password: "รหัสผ่าน"
         password_confirmation: "ยืนยันรหัสผ่าน"
         remember_me: "จำชื่อผู้ใช้"
-        reset_password_token: 
-        unlock_token: 
+        reset_password_token:
+        unlock_token:
     models:
-      user: "ผู้ใช้งาน"
+      user:
+        one: "ผู้ใช้งาน"
+        other: "ผู้ใช้"
   devise:
     confirmations:
       confirmed: "คุณได้ยืนยันบัญชีของคุณเรียบร้อยแล้ว ขณะนี้คุณสามารถเข้าสู่ระบบได้"
@@ -35,9 +37,9 @@ th:
         instruction: "คุณสามารถยืนยันอีเมล์ที่ใช้สมัครสมาชิกได้จากลิงค์ข้างล่างนี้:"
         subject: "คำแนะนำการยืนยัน"
       password_change:
-        greeting: 
-        message: 
-        subject: 
+        greeting:
+        message:
+        subject:
       reset_password_instructions:
         action: "เปลี่ยนรหัสผ่านของฉัน"
         greeting: "สวัสดีคุณ%{recipient}!"

--- a/rails/locales/tr.yml
+++ b/rails/locales/tr.yml
@@ -7,10 +7,12 @@ tr:
         password: Parola
         password_confirmation: Parola Doğrulama
         remember_me: Beni Hatırla
-        reset_password_token: 
-        unlock_token: 
+        reset_password_token:
+        unlock_token:
     models:
-      user: Kullanıcı
+      user:
+        one: Kullanıcı
+        other: Kullanıcılar
   devise:
     confirmations:
       confirmed: Hesabınız başarıyla onaylandı. Şu an giriş yapmış bulunuyorsunuz.

--- a/rails/locales/uk.yml
+++ b/rails/locales/uk.yml
@@ -10,7 +10,11 @@ uk:
         reset_password_token: "Посилання на скидання пароля"
         unlock_token: "Токен розблокування"
     models:
-      user: "Користувач"
+      user:
+        one: "Користувач"
+        few:
+        many:
+        other: "Користувачів"
   devise:
     confirmations:
       confirmed: "Ваш обліковий запис підтверджено. Ви увійшли в систему."

--- a/rails/locales/vi.yml
+++ b/rails/locales/vi.yml
@@ -7,10 +7,12 @@ vi:
         password: Mật khẩu
         password_confirmation: Xác nhận mật khẩu
         remember_me: Ghi nhớ đăng nhập
-        reset_password_token: 
-        unlock_token: 
+        reset_password_token:
+        unlock_token:
     models:
-      user: Người dùng
+      user:
+        one: Người dùng
+        other: Người sử dụng
   devise:
     confirmations:
       confirmed: Xác nhận tài khoản thành công! Bạn hiện đang đăng nhập.
@@ -35,9 +37,9 @@ vi:
         instruction: 'Bạn có thể xác nhận tài khoản email bằng liên kết dưới đây:'
         subject: Hướng dẫn xác nhận tài khoản
       password_change:
-        greeting: 
-        message: 
-        subject: 
+        greeting:
+        message:
+        subject:
       reset_password_instructions:
         action: Thay đổi mật khẩu
         greeting: Xin chào %{recipient}!

--- a/rails/locales/zh-CN.yml
+++ b/rails/locales/zh-CN.yml
@@ -7,10 +7,12 @@ zh-CN:
         password: "密码"
         password_confirmation: "密码确认"
         remember_me: "记住登录信息"
-        reset_password_token: 
-        unlock_token: 
+        reset_password_token:
+        unlock_token:
     models:
-      user: "用户"
+      user:
+        one: "用户"
+        other: "用户"
   devise:
     confirmations:
       confirmed: "恭喜您，注册成功，现在可以登录了"
@@ -35,9 +37,9 @@ zh-CN:
         instruction: "您可以通过下面的链接确认您的帐户的电子邮件:"
         subject: "确认信息"
       password_change:
-        greeting: 
-        message: 
-        subject: 
+        greeting:
+        message:
+        subject:
       reset_password_instructions:
         action: "更改我的密码"
         greeting: "你好 %{recipient}!"

--- a/rails/locales/zh-HK.yml
+++ b/rails/locales/zh-HK.yml
@@ -2,20 +2,22 @@ zh-HK:
   activerecord:
     attributes:
       user:
-        current_password: 
-        email: 
-        password: 
-        password_confirmation: 
-        remember_me: 
-        reset_password_token: 
-        unlock_token: 
+        current_password:
+        email:
+        password:
+        password_confirmation:
+        remember_me:
+        reset_password_token:
+        unlock_token:
     models:
-      user: 
+      user:
+        one:
+        other: 
   devise:
     confirmations:
       confirmed: "啟用同埋登入咗帳戶。"
       new:
-        resend_confirmation_instructions: 
+        resend_confirmation_instructions:
       send_instructions: "幾分鐘之後，你會收到一封電郵，入面有啟用帳戶嘅步驟。"
       send_paranoid_instructions: "如果我哋既紀錄入面有呢個電郵的話，幾分鐘之後，你會收到一封電郵，入面有啟用帳戶嘅步驟。"
     failure:
@@ -30,39 +32,39 @@ zh-HK:
       unconfirmed: "帳戶未啟用。"
     mailer:
       confirmation_instructions:
-        action: 
-        greeting: 
-        instruction: 
+        action:
+        greeting:
+        instruction:
         subject: "啟用帳戶"
       password_change:
-        greeting: 
-        message: 
-        subject: 
+        greeting:
+        message:
+        subject:
       reset_password_instructions:
-        action: 
-        greeting: 
-        instruction: 
-        instruction_2: 
-        instruction_3: 
+        action:
+        greeting:
+        instruction:
+        instruction_2:
+        instruction_3:
         subject: "重設密碼"
       unlock_instructions:
-        action: 
-        greeting: 
-        instruction: 
-        message: 
+        action:
+        greeting:
+        instruction:
+        message:
         subject: "帳戶解鎖"
     omniauth_callbacks:
       failure: "由%{kind}登入唔到，原因︰%{reason}。"
       success: "%{kind}登入成功。"
     passwords:
       edit:
-        change_my_password: 
-        change_your_password: 
-        confirm_new_password: 
-        new_password: 
+        change_my_password:
+        change_your_password:
+        confirm_new_password:
+        new_password:
       new:
-        forgot_your_password: 
-        send_me_reset_password_instructions: 
+        forgot_your_password:
+        send_me_reset_password_instructions:
       no_token: "請肯定網址係密碼重設電郵入面嗰個。唔經呢封電郵睇唔到呢版。"
       send_instructions: "幾分鐘之後，你會收到一封電郵，入面有重設密碼嘅步驟。"
       send_paranoid_instructions: "如果我哋既紀錄入面有呢個電郵的話，幾分鐘之後，你會收到一封電郵，入面有重設密碼嘅步驟。"
@@ -71,16 +73,16 @@ zh-HK:
     registrations:
       destroyed: "帳戶已經註銷。有緣再會。"
       edit:
-        are_you_sure: 
-        cancel_my_account: 
-        currently_waiting_confirmation_for_email: 
-        leave_blank_if_you_don_t_want_to_change_it: 
-        title: 
-        unhappy: 
-        update: 
-        we_need_your_current_password_to_confirm_your_changes: 
+        are_you_sure:
+        cancel_my_account:
+        currently_waiting_confirmation_for_email:
+        leave_blank_if_you_don_t_want_to_change_it:
+        title:
+        unhappy:
+        update:
+        we_need_your_current_password_to_confirm_your_changes:
       new:
-        sign_up: 
+        sign_up:
       signed_up: "註冊咗。歡迎！"
       signed_up_but_inactive: "註冊咗；不過要啟用埋帳戶先可以登入。"
       signed_up_but_locked: "註冊咗；不過帳戶鎖咗，未可以登入住。"
@@ -90,21 +92,21 @@ zh-HK:
     sessions:
       already_signed_out: "登出成功。"
       new:
-        sign_in: 
+        sign_in:
       signed_in: "登入咗。"
       signed_out: "登出咗。"
     shared:
       links:
-        back: 
-        didn_t_receive_confirmation_instructions: 
-        didn_t_receive_unlock_instructions: 
-        forgot_your_password: 
-        sign_in: 
-        sign_in_with_provider: 
-        sign_up: 
+        back:
+        didn_t_receive_confirmation_instructions:
+        didn_t_receive_unlock_instructions:
+        forgot_your_password:
+        sign_in:
+        sign_in_with_provider:
+        sign_up:
     unlocks:
       new:
-        resend_unlock_instructions: 
+        resend_unlock_instructions:
       send_instructions: "幾分鐘之後，你會收到一封電郵，入面有帳戶解鎖嘅步驟。"
       send_paranoid_instructions: "如果我哋既紀錄入面有呢個帳戶的話，幾分鐘之後，你會收到一封電郵，入面有帳戶解鎖嘅步驟。"
       unlocked: "帳戶解咗鎖；請重新登入。"

--- a/rails/locales/zh-TW.yml
+++ b/rails/locales/zh-TW.yml
@@ -10,7 +10,9 @@ zh-TW:
         reset_password_token:
         unlock_token:
     models:
-      user: "用戶"
+      user:
+        one: "用戶"
+        other: "用户"
   devise:
     confirmations:
       confirmed: "您的帳號已通過驗證，現在您已成功登入。"


### PR DESCRIPTION
On our project, we use the popular [i18n-tasks gem](https://github.com/glebm/i18n-tasks).  This creates a warning:

```ruby
rspec: [WARN] 'en.activerecord.models.user' was a leaf, now has children (value <- scope conflict)
```

This happens because while my own `activerecord.models.user` translations have a `one` and a `many` child, this gem's translations do not.  It's only a warning, but I suspect it may be more correct to include the pluralizations within this gem for the community to add to over time.

I've done my best to add many, but I did certainly not add them all.

I'd welcome feedback.  Thanks for this awesome gem!