### PR TITLE
Missing attributes from devise user model

### DIFF
--- a/rails/locales/en.yml
+++ b/rails/locales/en.yml
@@ -2,13 +2,29 @@ en:
   activerecord:
     attributes:
       user:
+        confirmation_sent_at: Confirmation sent at
+        confirmation_token: Confirmation token
+        confirmed_at: Confirmed at
+        created_at: Created at
         current_password: Current password
+        current_sign_in_at: Current sign in at
+        current_sign_in_ip: Current sign in IP
         email: Email
+        encrypted_password: Encrypted password
+        failed_attempts: Failed attempts
+        last_sign_in_at: Last sign in at
+        last_sign_in_ip: Last sign in IP
+        locked_at: Locked at
         password: Password
         password_confirmation: Password confirmation
+        remember_created_at: Remember created at
         remember_me: Remember me
+        reset_password_sent_at: Reset password sent at
         reset_password_token: Reset password token
+        sign_in_count: Sign in count
+        unconfirmed_email: Unconfirmed email
         unlock_token: Unlock token
+        updated_at: Updated at
     models:
       user: User
   devise:


### PR DESCRIPTION
I added the missing possible attributes, from every devise module, to the `en.yml` file. I think these are useful in many cases, e.g. an administration panel. In fact, [ActiveAdmin](https://github.com/activeadmin/activeadmin)'s default installation uses a few attributes not included before.

Should I add the missing keys to every other locale? Untranslated, of course. Although if this PR is accepted I can go ahead and translate the spanish ones :)