### PR TITLE
Update content of KO translations

### DIFF
--- a/rails/locales/ko.yml
+++ b/rails/locales/ko.yml
@@ -79,10 +79,6 @@ ko:
       new:
         forgot_your_password: "비밀번호를 잊으셨나요?"
         send_me_reset_password_instructions: "비밀번호 재설정 안내를 요청합니다"
-      expired:
-        renew_your_password: "암호 변경"
-        change_required: "암호 사용 기간 만료되었습니다. 암호를 변경하십시오."
-        change_required_days: "암호 사용 기간 (%{days} 일) 만료되었습니다. 암호를 변경하십시오."
       no_token: "비밀번호 재설정 이메일을 거치지 않고 이 페이지에 접근할 수 없습니다. 비밀번호 재설정 이메일에서 오셨다면, 주소가 제대로 되었는지 확인해 주세요."
       send_instructions: "잠시 후에 비밀번호 재설정 안내 메일을 받을 수 있습니다."
       send_paranoid_instructions: "회원정보에 등록된 이메일 주소와 동일하면, 몇 분 안에 비밀번호 재설정 주소를 이메일로 받으실 수 있습니다."

--- a/rails/locales/ko.yml
+++ b/rails/locales/ko.yml
@@ -2,29 +2,29 @@ ko:
   activerecord:
     attributes:
       user:
-        confirmation_sent_at: 
-        confirmation_token: 
-        confirmed_at: 
-        created_at: 
+        confirmation_sent_at:
+        confirmation_token:
+        confirmed_at:
+        created_at:
         current_password: "현재 비밀번호"
-        current_sign_in_at: 
-        current_sign_in_ip: 
+        current_sign_in_at:
+        current_sign_in_ip: "현재 접속 IP주소"
         email: "이메일"
-        encrypted_password: 
-        failed_attempts: 
-        last_sign_in_at: 
-        last_sign_in_ip: 
-        locked_at: 
+        encrypted_password: "암호화된 비밀번호"
+        failed_attempts: "접속시도 실패"
+        last_sign_in_at: "마지막 접속위치"
+        last_sign_in_ip: "마지막 접속 IP주소"
+        locked_at:
         password: "비밀번호"
         password_confirmation: "비밀번호 확인"
-        remember_created_at: 
+        remember_created_at:
         remember_me: "로그인 정보 기억하기"
-        reset_password_sent_at: 
-        reset_password_token: 
-        sign_in_count: 
-        unconfirmed_email: 
-        unlock_token: 
-        updated_at: 
+        reset_password_sent_at: "재설정된 암호 발송"
+        reset_password_token: "재설정된 암호 토큰"
+        sign_in_count:
+        unconfirmed_email: "확인되지 않은 이메일 주소"
+        unlock_token:
+        updated_at:
     models:
       user: "사용자"
   devise:
@@ -52,8 +52,8 @@ ko:
         subject: "이메일 인증 안내"
       password_change:
         greeting: "%{recipient}님"
-        message:
-        subject:
+        message: "당신의 계정 비밀번호가 변경되었음을 알려드립니다."
+        subject: "비밀번호가 변경되었습니다"
       reset_password_instructions:
         action: "비밀번호 변경"
         greeting: "%{recipient}님"

--- a/rails/locales/ko.yml
+++ b/rails/locales/ko.yml
@@ -2,29 +2,29 @@ ko:
   activerecord:
     attributes:
       user:
-        confirmation_sent_at:
-        confirmation_token:
-        confirmed_at:
-        created_at:
+        confirmation_sent_at: "확인 메일 전송 시간"
+        confirmation_token: "확인 토큰"
+        confirmed_at: "확인된 시간"
+        created_at: "생성된 시간"
         current_password: "현재 비밀번호"
-        current_sign_in_at:
+        current_sign_in_at: "현재 접속 시간"
         current_sign_in_ip: "현재 접속 IP주소"
         email: "이메일"
         encrypted_password: "암호화된 비밀번호"
         failed_attempts: "접속시도 실패"
-        last_sign_in_at: "마지막 접속위치"
+        last_sign_in_at: "마지막 접속 시간"
         last_sign_in_ip: "마지막 접속 IP주소"
-        locked_at:
+        locked_at: "접근 잠김 시간"
         password: "비밀번호"
         password_confirmation: "비밀번호 확인"
-        remember_created_at:
+        remember_created_at: "로그인 기록된  시간"
         remember_me: "로그인 정보 기억하기"
         reset_password_sent_at: "재설정된 암호 발송"
         reset_password_token: "재설정된 암호 토큰"
-        sign_in_count:
+        sign_in_count: "로그인 수"
         unconfirmed_email: "확인되지 않은 이메일 주소"
-        unlock_token:
-        updated_at:
+        unlock_token: "잠금해제 토큰"
+        updated_at: "업데이트된 시간"
     models:
       user: "사용자"
   devise:

--- a/rails/locales/ko.yml
+++ b/rails/locales/ko.yml
@@ -33,37 +33,37 @@ ko:
       new:
         resend_confirmation_instructions: "인증 안내 재발송"
       send_instructions: "이메일로 이메일 주소 인증 안내가 발송되었습니다."
-      send_paranoid_instructions: "이메일 주소가 존재한다면 메일로 이메일 인증 안내 메일을 받을 수 있습니다."
+      send_paranoid_instructions: "이메일 주소가 존재한다면 메일로 인증 안내 메일을 받을 수 있습니다."
     failure:
       already_authenticated: "이미 로그인되어 있습니다."
       inactive: "계정이 아직 활성화되지 않았습니다."
-      invalid: "이메일 혹은 비밀번호가 틀립니다."
+      invalid: "아이디 또는 비밀번호를 잘못 입력하셨습니다."
       last_attempt: "이번 로그인 시도를 실패하면 계정이 잠깁니다."
       locked: "계정이 잠겨있습니다."
-      not_found_in_database: "이메일 주소나 비밀번호가 틀립니다."
+      not_found_in_database: "이메일 주소 또는 비밀번호가 틀립니다."
       timeout: "세션이 만료되었습니다. 계속하려면 다시 로그인해야 합니다."
       unauthenticated: "계속하려면 로그인하거나 가입해야 합니다."
       unconfirmed: "계속하기 전에 이메일 주소를 인증해야 합니다."
     mailer:
       confirmation_instructions:
         action: "본인 계정 인증"
-        greeting: "%{recipient}님 환영합니다!"
-        instruction: "아래의 링크를 클릭하시면 이메일 인증이 완료됩니다:"
+        greeting: "%{recipient}님"
+        instruction: "아래 링크를 클릭하시면 이메일 인증이 완료됩니다:"
         subject: "이메일 인증 안내"
       password_change:
-        greeting: 
-        message: 
-        subject: 
+        greeting: "%{recipient}님"
+        message:
+        subject:
       reset_password_instructions:
         action: "비밀번호 변경"
-        greeting: "%{recipient}님 안녕하세요!"
+        greeting: "%{recipient}님"
         instruction: "누군가 당신의 비밀번호를 변경하는 링크를 요청했으며, 다음의 링크에서 비밀번호 변경이 가능합니다."
         instruction_2: "비밀번호 변경을 요청하지 않으셨다면 이 메일을 무시하십시오."
         instruction_3: "위 링크에 접속하여 새로운 비밀번호를 생성하기 전까지 귀하의 비밀번호는 변경되지 않습니다."
         subject: "비밀번호 재설정 안내"
       unlock_instructions:
         action: "본인 계정 잠금 해제"
-        greeting: "%{recipient}님 안녕하세요!"
+        greeting: "%{recipient}님"
         instruction: "계정 잠금을 해제하려면 아래 링크를 클릭하세요."
         message: "로그인 실패 횟수 초과로 귀하의 계정이 잠금 처리되었습니다."
         subject: "잠금 해제 안내"
@@ -79,36 +79,40 @@ ko:
       new:
         forgot_your_password: "비밀번호를 잊으셨나요?"
         send_me_reset_password_instructions: "비밀번호 재설정 안내를 요청합니다"
+      expired:
+        renew_your_password: "암호 변경"
+        change_required: "암호 사용 기간 만료되었습니다. 암호를 변경하십시오."
+        change_required_days: "암호 사용 기간 (%{days} 일) 만료되었습니다. 암호를 변경하십시오."
       no_token: "비밀번호 재설정 이메일을 거치지 않고 이 페이지에 접근할 수 없습니다. 비밀번호 재설정 이메일에서 오셨다면, 주소가 제대로 되었는지 확인해 주세요."
       send_instructions: "잠시 후에 비밀번호 재설정 안내 메일을 받을 수 있습니다."
-      send_paranoid_instructions: "이메일이 데이터베이스에 존재할 경우, 몇 분 안에 비밀번호 재설정 주소를 이메일로 받으실 수 있습니다."
+      send_paranoid_instructions: "회원정보에 등록된 이메일 주소와 동일하면, 몇 분 안에 비밀번호 재설정 주소를 이메일로 받으실 수 있습니다."
       updated: "성공적으로 비밀번호를 변경했습니다. 로그인 되었습니다."
       updated_not_active: "비밀번호가 성공적으로 변경되었습니다."
     registrations:
-      destroyed: "안녕히 가세요! 계정이 성공적으로 탈퇴되었습니다. 다시 볼 수 있기를 바랍니다."
+      destroyed: "회원님의 계정이 성공적으로 탈퇴처리 되었습니다. 다시 볼 수 있기를 바랍니다."
       edit:
         are_you_sure: "정말로 탈퇴하시겠습니까?"
         cancel_my_account: "회원 탈퇴"
-        currently_waiting_confirmation_for_email: "현재 다음 이메일 인증 대기중입니다: %{email}"
+        currently_waiting_confirmation_for_email: "현재 이메일 인증 대기중 입니다: %{email}"
         leave_blank_if_you_don_t_want_to_change_it: "변경을 원하지 않으시면 빈 칸으로 남겨주세요"
         title: "%{resource} 정보 수정"
         unhappy: "회원 탈퇴를 하시겠습니까?"
         update: "변경"
-        we_need_your_current_password_to_confirm_your_changes: "변경 사항을 반영하려면 현재의 비밀번호를 입력하세요"
+        we_need_your_current_password_to_confirm_your_changes: "변경 사항을 반영하려면 현재 비밀번호를 입력하세요"
       new:
         sign_up: "회원 가입"
-      signed_up: "환영합니다! 성공적으로 가입되었습니다."
+      signed_up: "환영합니다! 성공적으로 가입 되었습니다."
       signed_up_but_inactive: "성공적으로 가입되었지만, 아직 계정이 활성화되어 있지 않아 로그인 할 수 없습니다."
       signed_up_but_locked: "성공적으로 가입되었지만, 계정이 잠겨있어 로그인 할 수 없습니다."
       signed_up_but_unconfirmed: "인증 주소가 포함된 메시지를 이메일 주소로 보냈습니다. 계정을 활성화하기 위해 메일을 확인하세요."
-      update_needs_confirmation: "계정이 성공적으로 수정되었지만, 새로운 이메일 주소를 확인해야 합니다. 이메일로 전송된 이메일 인증 주소를 클릭하여 새로운 이메일 주소를 인증해 주세요."
+      update_needs_confirmation: "계정이 성공적으로 수정되었지만, 새로운 이메일 주소를 확인해야 합니다. 이메일로 전송된 인증 주소를 클릭하여 새로운 이메일 주소를 인증해 주세요."
       updated: "계정이 성공적으로 수정되었습니다."
     sessions:
-      already_signed_out: "성공적으로 로그아웃되었습니다."
+      already_signed_out: "성공적으로 로그아웃 되었습니다."
       new:
         sign_in: "로그인"
-      signed_in: "성공적으로 로그인되었습니다."
-      signed_out: "성공적으로 로그아웃되었습니다."
+      signed_in: "성공적으로 로그인 되었습니다."
+      signed_out: "성공적으로 로그아웃 되었습니다."
     shared:
       links:
         back: "돌아가기"
@@ -123,10 +127,10 @@ ko:
         resend_unlock_instructions: "계정 잠금 해제 재요청"
       send_instructions: "잠시 후 이메일로 계정 잠금 해제 안내를 받아보실 수 있습니다."
       send_paranoid_instructions: "계정이 존재한다면 메일로 계정 잠금 해제 안내를 받을 수 있습니다."
-      unlocked: "계정이 성공적으로 잠금 해제되었습니다. 로그인하여 계속해 주세요."
+      unlocked: "계정이 성공적으로 잠금 해제되었습니다. 새로 로그인해 주세요."
   errors:
     messages:
-      already_confirmed: "은(는) 이미 인증되었습니다. 다시 로그인해 보세요."
+      already_confirmed: "은(는) 이미 인증되었습니다. 다시 로그인 해보세요."
       confirmation_period_expired: "%{period} 이내에 이메일 인증을 해야 합니다. 새로 요청해 주세요."
       expired: "이(가) 만료되었습니다 새로 요청해 주세요."
       not_found: "찾을 수 없습니다."

--- a/rails/locales/ko.yml
+++ b/rails/locales/ko.yml
@@ -17,7 +17,7 @@ ko:
         locked_at: "접근 잠김 시간"
         password: "비밀번호"
         password_confirmation: "비밀번호 확인"
-        remember_created_at: "로그인 기록된  시간"
+        remember_created_at: "로그인 기록된 시간"
         remember_me: "로그인 정보 기억하기"
         reset_password_sent_at: "재설정된 암호 발송"
         reset_password_token: "재설정된 암호 토큰"


### PR DESCRIPTION
These have been reviewed by a native speaker.

Aside from grammar fixes the only content change is to increase the formality of the greeting:
"%{recipient}님 안녕하세요!" --> "%{recipient}님". The old one was informal (Hello ___) and the new one is more formal which is safer for a more broad range of usage scenarios. Incidentally we do the same thing in Japanese with 様 (sama).