### PR TITLE
Change confirmation mail greeting to also fit use for reconfirmation

### DIFF
--- a/rails/locales/da.yml
+++ b/rails/locales/da.yml
@@ -47,7 +47,7 @@ da:
     mailer:
       confirmation_instructions:
         action: Bekræft min konto
-        greeting: Velkommen %{recipient}
+        greeting: Hej %{recipient}
         instruction: 'Du kan bekræfte din konto og e-mail via linket herunder:'
         subject: Bekræftelsesinstruktioner
       email_changed:

--- a/rails/locales/en-GB.yml
+++ b/rails/locales/en-GB.yml
@@ -47,7 +47,7 @@ en-GB:
     mailer:
       confirmation_instructions:
         action: Confirm my account
-        greeting: Welcome %{recipient}!
+        greeting: Hello %{recipient}!
         instruction: 'You can confirm your account email through the link below:'
         subject: Confirmation instructions
       email_changed:

--- a/rails/locales/en.yml
+++ b/rails/locales/en.yml
@@ -47,7 +47,7 @@ en:
     mailer:
       confirmation_instructions:
         action: Confirm my account
-        greeting: Welcome %{recipient}!
+        greeting: Hello %{recipient}!
         instruction: 'You can confirm your account email through the link below:'
         subject: Confirmation instructions
       email_changed:


### PR DESCRIPTION
The mailer.confirmation_instructions.greeting translation is also used by the re-confirmation e-mail, sent by devise. In that context, the "Welcome" greeting doesn't make sense, so a more general greeting is better suited.