### PR TITLE
One/other keys for model names

### DIFF
--- a/rails/locales/en-GB.yml
+++ b/rails/locales/en-GB.yml
@@ -26,7 +26,9 @@ en-GB:
         unlock_token: Unlock token
         updated_at: 
     models:
-      user: User
+      user:
+        one: User
+        other: Users
   devise:
     confirmations:
       confirmed: Your account was successfully confirmed.

--- a/rails/locales/en.yml
+++ b/rails/locales/en.yml
@@ -26,7 +26,9 @@ en:
         unlock_token: Unlock token
         updated_at: Updated at
     models:
-      user: User
+      user:
+        one: User
+        other: Users
   devise:
     confirmations:
       confirmed: Your email address has been successfully confirmed.

--- a/rails/locales/es-MX.yml
+++ b/rails/locales/es-MX.yml
@@ -26,7 +26,9 @@ es-MX:
         unlock_token: Autentificador de desbloqueo
         updated_at: Fecha de actualización
     models:
-      user: Usuario
+      user:
+        one: Usuario
+        other: Usuarios
   devise:
     confirmations:
       confirmed: Se ha confirmado la dirección de correo electrónico correctamente.

--- a/rails/locales/es.yml
+++ b/rails/locales/es.yml
@@ -26,7 +26,9 @@ es:
         unlock_token: Código de desbloqueo
         updated_at: Actualizado en
     models:
-      user: Usuario
+      user:
+        one: Usuario
+        other: Usuarios
   devise:
     confirmations:
       confirmed: Tu cuenta ha sido confirmada satisfactoriamente.


### PR DESCRIPTION
This style of storing model names is more useful, because it contemplates the use case of giving a `count: 2` parameter, which is used by, for example, [ActiveAdmin](https://github.com/activeadmin/activeadmin) in menu titles.

It [preserves current functionality](https://guides.rubyonrails.org/i18n.html#translations-for-active-record-models) when using `User.model_name.human` but it will break if anyone is using `I18n.t('activerecord.models.user')` directly, so I recommend merging on a version change, maybe.

