### PR TITLE
Update locale it.yml

### DIFF
--- a/rails/locales/it.yml
+++ b/rails/locales/it.yml
@@ -26,14 +26,16 @@ it:
         unlock_token: Token di sblocco
         updated_at: Aggiornato il
     models:
-      user: Utente
+      user:
+        one: Utente
+        other: Utenti
   devise:
     confirmations:
       confirmed: Il tuo account è stato correttamente confermato.
       new:
         resend_confirmation_instructions: Invia di nuovo le istruzioni per la conferma
       send_instructions: Riceverai un messaggio email con le istruzioni per confermare il tuo account entro qualche minuto.
-      send_paranoid_instructions: Se la tua e-mail esiste nel nostro database, riceverai un messaggio email con le istruzioni per confermare il tuo account entro qualche minuto.
+      send_paranoid_instructions: Se la tua email esiste nel nostro database, riceverai un messaggio email con le istruzioni per confermare il tuo account entro qualche minuto.
     failure:
       already_authenticated: Hai già effettuato l'accesso.
       inactive: Il tuo account non è stato ancora attivato.
@@ -85,11 +87,11 @@ it:
         send_me_reset_password_instructions: Inviami le istruzioni per resettare la password
       no_token: Puoi accedere a questa pagina solamente dalla email di reset della password. Se vieni dalla email controlla di aver inserito l'url completo riportato nella email.
       send_instructions: Riceverai un messaggio email con le istruzioni per reimpostare la tua password entro qualche minuto.
-      send_paranoid_instructions: Se la tua e-mail esiste nel nostro database, riceverai un messaggio email contentente un link per il ripristino della password
+      send_paranoid_instructions: Se la tua email esiste nel nostro database, riceverai un messaggio email contentente un link per il ripristino della password
       updated: La tua password è stata cambiata. Ora sei collegato.
       updated_not_active: La tua password è stata cambiata.
     registrations:
-      destroyed: Arrivederci! L'account è stato cancellato. Speriamo di rivederci presto.
+      destroyed: Arrivederci! L'account è stato cancellato. Speriamo di rivederti presto.
       edit:
         are_you_sure: Sei sicuro?
         cancel_my_account: Rimuovi il mio account
@@ -129,7 +131,7 @@ it:
       new:
         resend_unlock_instructions: Invia di nuovo le istruzioni per lo sblocco
       send_instructions: Riceverai un messaggio email con le istruzioni per sbloccare il tuo account entro qualche minuto.
-      send_paranoid_instructions: Se la tua e-mail esiste nel nostro database, riceverai un messaggio email con le istruzioni per sbloccare il tuo account entro qualche minuto.
+      send_paranoid_instructions: Se la tua email esiste nel nostro database, riceverai un messaggio email con le istruzioni per sbloccare il tuo account entro qualche minuto.
       unlocked: Il tuo account è stato correttamente sbloccato. Ora sei collegato.
   errors:
     messages:


### PR DESCRIPTION
I noticed some lines where "email" and "e-mail" are used together and it looks odd. I replaced "e-mail" with "email" so that the translation is more consistent. I've also added the distinction between *one* and *other* in *user* model as I saw in en.yml.