### PR TITLE
Update de.yml

### DIFF
--- a/rails/locales/de.yml
+++ b/rails/locales/de.yml
@@ -8,7 +8,7 @@ de:
         created_at: Erstellt am
         current_password: Bisheriges Passwort
         current_sign_in_at: Aktuelle Anmeldung vom
-        current_sign_in_ip: IP aktueller Anmeldung
+        current_sign_in_ip: IP der aktuellen Anmeldung
         email: E-Mail
         encrypted_password: Verschlüsseltes Passwort
         failed_attempts: Fehlversuche
@@ -29,34 +29,34 @@ de:
       user: Benutzer
   devise:
     confirmations:
-      confirmed: Ihre E-Mail Adresse wurde erfolgreich bestätigt.
+      confirmed: Ihre E-Mail-Adresse wurde erfolgreich bestätigt.
       new:
         resend_confirmation_instructions: Anleitung zur Bestätigung noch mal schicken
       send_instructions: Sie erhalten in wenigen Minuten eine E-Mail, mit der Sie Ihre Registrierung bestätigen können.
       send_paranoid_instructions: Falls Ihre E-Mail-Adresse in unserer Datenbank existiert, erhalten Sie in wenigen Minuten eine E-Mail, mit der Sie Ihre Registrierung bestätigen können.
     failure:
       already_authenticated: Sie sind bereits angemeldet.
-      inactive: Ihr Account ist nicht aktiv.
+      inactive: Ihr Konto ist nicht aktiv.
       invalid: "%{authentication_keys} oder Passwort ungültig."
-      last_attempt: Sie haben noch einen Versuch, bis Ihr Account gesperrt wird.
-      locked: Ihr Account ist gesperrt.
+      last_attempt: Sie haben noch einen Versuch, bis Ihr Konto gesperrt wird.
+      locked: Ihr Konto ist gesperrt.
       not_found_in_database: "%{authentication_keys} oder Passwort ungültig."
       timeout: Ihre Sitzung ist abgelaufen, bitte melden Sie sich erneut an.
       unauthenticated: Sie müssen sich anmelden oder registrieren, bevor Sie fortfahren können.
-      unconfirmed: Sie müssen Ihren Account bestätigen, bevor Sie fortfahren können.
+      unconfirmed: Sie müssen Ihr Konto bestätigen, bevor Sie fortfahren können.
     mailer:
       confirmation_instructions:
         action: Mein Konto bestätigen
         greeting: Willkommen %{recipient}!
         instruction: 'Folgen Sie dem untenstehenden Link, um Ihr Konto zu bestätigen:'
-        subject: Anleitung zur Bestätigung Ihres Accounts
+        subject: Anleitung zur Bestätigung Ihres Kontos
       email_changed:
         greeting: Hallo %{recipient}!
-        message: Wir schreiben Ihnen, um Sie darüber zu informieren, dass Ihre E-Mail zu %{email} geändert wurde.
-        subject: E-Mail geändert
+        message: Wir schreiben Ihnen, um Sie darüber zu informieren, dass Ihre E-Mail-Adresse zu %{email} geändert wurde.
+        subject: E-Mail-Adresse geändert
       password_change:
         greeting: Hallo %{recipient}!
-        message: Wir kontaktieren Sie, um Ihnen mitzuteilen, dass Ihr Passwort geändert wurde.
+        message: Wir schreiben Ihnen, um Sie darüber zu informieren, dass Ihr Passwort geändert wurde.
         subject: Passwort geändert
       reset_password_instructions:
         action: Passwort ändern
@@ -70,10 +70,10 @@ de:
         greeting: Hallo %{recipient}!
         instruction: 'Folgen Sie dem untenstehenden Link, um Ihr Konto zu entsperren:'
         message: Ihr Konto wurde aufgrund einer großen Anzahl von fehlgeschlagenen Anmeldeversuchen gesperrt.
-        subject: Anleitung für die Account-Freischaltung
+        subject: Anleitung für die Konto-Freischaltung
     omniauth_callbacks:
-      failure: Sie konnten nicht mit Ihrem %{kind}-Account angemeldet werden, weil "%{reason}".
-      success: Sie haben sich erfolgreich mit Ihrem %{kind}-Account angemeldet.
+      failure: Sie konnten nicht mit Ihrem %{kind}-Konto angemeldet werden, weil "%{reason}".
+      success: Sie haben sich erfolgreich mit Ihrem %{kind}-Konto angemeldet.
     passwords:
       edit:
         change_my_password: "Ändere mein Passwort"
@@ -89,22 +89,22 @@ de:
       updated: Ihr Passwort wurde geändert. Sie sind jetzt angemeldet.
       updated_not_active: Ihr Passwort wurde geändert.
     registrations:
-      destroyed: Ihr Account wurde gelöscht.
+      destroyed: Ihr Konto wurde gelöscht.
       edit:
         are_you_sure: Sind Sie sicher?
         cancel_my_account: Konto löschen
         currently_waiting_confirmation_for_email: Warte auf Bestätigung von %{email}.
         leave_blank_if_you_don_t_want_to_change_it: freilassen, wenn Sie das nicht ändern wollen
         title: "%{resource} bearbeiten"
-        unhappy: Unglücklich?
+        unhappy: Unzufrieden?
         update: Aktualisieren
         we_need_your_current_password_to_confirm_your_changes: wir benötigen Ihr aktuelles Passwort, um die Änderung zu bestätigen
       new:
         sign_up: Registrieren
       signed_up: Sie haben sich erfolgreich registriert.
-      signed_up_but_inactive: Sie haben sich erfolgreich registriert. Wir konnten Sie jedoch nicht anmelden, weil Ihr Account noch nicht aktiviert ist.
-      signed_up_but_locked: Sie haben sich erfolgreich registriert. Wir konnten Sie jedoch nicht anmelden, weil Ihr Account gesperrt ist.
-      signed_up_but_unconfirmed: Sie erhalten in wenigen Minuten eine E-Mail mit einem Link für die Bestätigung der Registrierung. Klicken Sie auf den Link um Ihren Account zu aktivieren.
+      signed_up_but_inactive: Sie haben sich erfolgreich registriert. Wir konnten Sie jedoch nicht anmelden, weil Ihr Konto noch nicht aktiviert ist.
+      signed_up_but_locked: Sie haben sich erfolgreich registriert. Wir konnten Sie jedoch nicht anmelden, weil Ihr Konto gesperrt ist.
+      signed_up_but_unconfirmed: Sie erhalten in wenigen Minuten eine E-Mail mit einem Link für die Bestätigung der Registrierung. Klicken Sie auf den Link um Ihr Konto zu aktivieren.
       update_needs_confirmation: Ihre Daten wurden aktualisiert, aber Sie müssen Ihre neue E-Mail-Adresse bestätigen. Sie erhalten in wenigen Minuten eine E-Mail, mit der Sie die Änderung Ihrer E-Mail-Adresse abschließen können.
       updated: Ihre Daten wurden aktualisiert.
     sessions:
@@ -128,9 +128,9 @@ de:
     unlocks:
       new:
         resend_unlock_instructions: Anleitung zum Entsperren noch mal schicken
-      send_instructions: Sie erhalten in wenigen Minuten eine E-Mail mit der Anleitung, wie Sie Ihren Account entsperren können.
-      send_paranoid_instructions: Falls Ihre E-Mail-Adresse in unserer Datenbank existiert, erhalten Sie in wenigen Minuten eine E-Mail, mit der Anleitung, wie Sie Ihren Account entsperren können.
-      unlocked: Ihr Account wurde entsperrt. Bitte melden Sie sich an, um fortzufahren.
+      send_instructions: Sie erhalten in wenigen Minuten eine E-Mail mit der Anleitung, wie Sie Ihr Konto entsperren können.
+      send_paranoid_instructions: Falls Ihre E-Mail-Adresse in unserer Datenbank existiert, erhalten Sie in wenigen Minuten eine E-Mail, mit der Anleitung, wie Sie Ihr Konto entsperren können.
+      unlocked: Ihr Konto wurde entsperrt. Bitte melden Sie sich an, um fortzufahren.
   errors:
     messages:
       already_confirmed: wurde bereits bestätigt, bitte versuchen Sie, sich anzumelden


### PR DESCRIPTION
Harmonize and correct some terms, spelling fixes:

- Consistently use **Konto** instead of **Account** for all translations
- Consistently translate _email_changed.message_ and _password_change.message_
- Consistently translate _current_sign_in_ip_ and _last_sign_in_ip_
- Spelling fix: **E-Mail-Adresse** ("Durchkopplung")
- More precise translation for _unhappy_