### PR TITLE
do not downcase model name in errors (fixes #260)

### DIFF
--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -3,7 +3,7 @@
     <h2>
       <%= I18n.t("errors.messages.not_saved",
                  count: resource.errors.count,
-                 resource: resource.class.model_name.human.downcase)
+                 resource: resource.class.model_name.human)
        %>
     </h2>
     <ul>


### PR DESCRIPTION
I don't know what is the "right" way to define keys in vanilla rails
i18n model translations regarding uppercased/downcased model names.

In German, all Nouns start with a capital Letter, thus for correct
German spelling without this patch you need to `rails g devise:views`
and adjust the `_error_messages.html.erb` template.  I'd prefer this
working out of the box, but cannot judge the implications for other
locales.