### PR TITLE
Update es.yml

### DIFF
--- a/rails/locales/es.yml
+++ b/rails/locales/es.yml
@@ -136,7 +136,7 @@ es:
       unlocked: Tu cuenta ha sido desbloqueada. Ya puedes iniciar sesión.
   errors:
     messages:
-      already_confirmed: ya ha sido confirmada, por favor intenta iniciar sesión
+      already_confirmed: ya ha sido confirmado, por favor intenta iniciar sesión
       confirmation_period_expired: necesita confirmarse dentro de %{period}, por favor solicita una nueva
       expired: ha expirado, por favor solicita una nueva
       not_found: no se ha encontrado


### PR DESCRIPTION
´already_confirmed´ references an email. In spanish, mail is assigned with a male gender. So it should be "confirmado" instead of "confirmada".