### PR TITLE
fix ja.yml (fix word inconsistency and syntax mistake)

### DIFF
--- a/rails/locales/ja.yml
+++ b/rails/locales/ja.yml
@@ -26,7 +26,7 @@ ja:
         unlock_token: ロック解除用トークン
         updated_at: 更新日
     models:
-      user: ユーザ
+      user: ユーザー
   devise:
     confirmations:
       confirmed: メールアドレスが確認できました。
@@ -39,7 +39,7 @@ ja:
       inactive: アカウントが有効化されていません。メールに記載された手順にしたがって、アカウントを有効化してください。
       invalid: "%{authentication_keys}またはパスワードが違います。"
       last_attempt: もう一回誤るとアカウントがロックされます。
-      locked: アカウントは凍結されています。
+      locked: アカウントはロックされています。
       not_found_in_database: "%{authentication_keys}またはパスワードが違います。"
       timeout: セッションがタイムアウトしました。もう一度ログインしてください。
       unauthenticated: アカウント登録もしくはログインしてください。
@@ -52,12 +52,12 @@ ja:
         subject: メールアドレス確認メール
       email_changed:
         greeting: こんにちは、%{recipient}様。
-        message: あなたのメール変更（%{email}）のお知らせいたします。
+        message: あなたのメールの変更（%{email}）をお知らせいたします。
         message_unconfirmed: 
-        subject: メール変更完了。
+        subject: メール変更完了
       password_change:
         greeting: "%{recipient}様"
-        message: パスワードが再設定されたことを通知します。
+        message: パスワードが再設定されました。
         subject: パスワードの変更について
       reset_password_instructions:
         action: パスワード変更
@@ -71,7 +71,7 @@ ja:
         greeting: "%{recipient}様"
         instruction: アカウントのロックを解除するには下のリンクをクリックしてください。
         message: ログイン失敗が繰り返されたため、アカウントはロックされています。
-        subject: アカウントの凍結解除について
+        subject: アカウントのロック解除について
     omniauth_callbacks:
       failure: "%{kind} アカウントによる認証に失敗しました。理由：（%{reason}）"
       success: "%{kind} アカウントによる認証に成功しました。"
@@ -82,7 +82,7 @@ ja:
         confirm_new_password: 確認用新しいパスワード
         new_password: 新しいパスワード
       new:
-        forgot_your_password: パスワードを忘れましたか?
+        forgot_your_password: パスワードを忘れましたか？
         send_me_reset_password_instructions: パスワードの再設定方法を送信する
       no_token: このページにはアクセスできません。パスワード再設定メールのリンクからアクセスされた場合には、URL をご確認ください。
       send_instructions: パスワードの再設定について数分以内にメールでご連絡いたします。
@@ -92,7 +92,7 @@ ja:
     registrations:
       destroyed: アカウントを削除しました。またのご利用をお待ちしております。
       edit:
-        are_you_sure: 本当によろしいですか?
+        are_you_sure: 本当によろしいですか？
         cancel_my_account: アカウント削除
         currently_waiting_confirmation_for_email: "%{email} の確認待ち"
         leave_blank_if_you_don_t_want_to_change_it: 空欄のままなら変更しません
@@ -104,7 +104,7 @@ ja:
         sign_up: アカウント登録
       signed_up: アカウント登録が完了しました。
       signed_up_but_inactive: ログインするためには、アカウントを有効化してください。
-      signed_up_but_locked: アカウントが凍結されているためログインできません。
+      signed_up_but_locked: アカウントがロックされているためログインできません。
       signed_up_but_unconfirmed: 本人確認用のメールを送信しました。メール内のリンクからアカウントを有効化させてください。
       update_needs_confirmation: アカウント情報を変更しました。変更されたメールアドレスの本人確認のため、本人確認用メールより確認処理をおこなってください。
       updated: アカウント情報を変更しました。
@@ -118,26 +118,26 @@ ja:
     shared:
       links:
         back: 戻る
-        didn_t_receive_confirmation_instructions: アカウント確認のメールを受け取っていませんか?
-        didn_t_receive_unlock_instructions: アカウントの凍結解除方法のメールを受け取っていませんか?
-        forgot_your_password: パスワードを忘れましたか?
+        didn_t_receive_confirmation_instructions: アカウント確認のメールを受け取っていませんか？
+        didn_t_receive_unlock_instructions: アカウントのロック解除方法のメールを受け取っていませんか？
+        forgot_your_password: パスワードを忘れましたか？
         sign_in: ログイン
         sign_in_with_provider: "%{provider}でログイン"
         sign_up: アカウント登録
       minimum_password_length: "（%{count}字以上）"
     unlocks:
       new:
-        resend_unlock_instructions: アカウントの凍結解除方法を再送する
-      send_instructions: アカウントの凍結解除方法を数分以内にメールでご連絡します。
-      send_paranoid_instructions: アカウントが見つかった場合、アカウントの凍結解除方法を数分以内にメールでご連絡します。
-      unlocked: アカウントを凍結解除しました。
+        resend_unlock_instructions: アカウントのロック解除方法を再送する
+      send_instructions: アカウントのロック解除方法を数分以内にメールでご連絡します。
+      send_paranoid_instructions: アカウントが見つかった場合、アカウントのロック解除方法を数分以内にメールでご連絡します。
+      unlocked: アカウントをロック解除しました。
   errors:
     messages:
       already_confirmed: は既に登録済みです。ログインしてください。
       confirmation_period_expired: の期限が切れました。%{period} までに確認する必要があります。 新しくリクエストしてください。
       expired: の有効期限が切れました。新しくリクエストしてください。
       not_found: は見つかりませんでした。
-      not_locked: は凍結されていません。
+      not_locked: はロックされていません。
       not_saved:
         one: エラーが発生したため %{resource} は保存されませんでした。
         other: "%{count} 件のエラーが発生したため %{resource} は保存されませんでした。"


### PR DESCRIPTION
#### Simple fixes to ja.yml
- fix inconsistency
Different words (凍結 and ロック) were used to the same English word (lock).
- Minor wording
For "User", "ユーザ" is not common. Replaced with "ユーザー"
- Minor syntax mistake
Double-space question mark "？" should be used rather than "?".
End of the sentence period ("。") should not be put to email subject.
- One obvious syntax error
Usage of "の" (similar to "of" of English) was incorrect.