### PR TITLE
Fix typo in de.yml

### DIFF
--- a/rails/locales/de.yml
+++ b/rails/locales/de.yml
@@ -64,7 +64,7 @@ de:
       reset_password_instructions:
         action: Passwort ändern
         greeting: Hallo %{recipient}!
-        instruction: Jemand hat einen Link angefordert, um Ihr Passwort zu ändern. Klicken Sie auf den unten aufgeführten Link um das Passwort zu ändern.
+        instruction: Jemand hat einen Link angefordert, um Ihr Passwort zu ändern. Klicken Sie auf den unten aufgeführten Link, um das Passwort zu ändern.
         instruction_2: Bitte ignorieren Sie diese E-Mail, wenn Sie kein neues Passwort angefordert haben.
         instruction_3: Das Passwort wird nicht geändert bis Sie den obenstehenden Link abrufen und ein neues Passwort bestimmen.
         subject: Anleitung für das Zurücksetzen Ihres Passworts


### PR DESCRIPTION
Add missing comma before "um".

More details why the comma is needed there can be found here for example: https://www.sprachschach.de/komma-vor-um/