### PR TITLE
change omniauth_authorize_path to use POST to follow devise 4.8.0 template

### DIFF
--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -20,6 +20,6 @@
 
 <%- if devise_mapping.omniauthable? %>
   <%- resource_class.omniauth_providers.each do |provider| %>
-    <%= link_to t('.sign_in_with_provider', provider: OmniAuth::Utils.camelize(provider)), omniauth_authorize_path(resource_name, provider) %><br />
+    <%= link_to t('.sign_in_with_provider', provider: OmniAuth::Utils.camelize(provider)), omniauth_authorize_path(resource_name, provider), method: :post %><br />
   <% end %>
 <% end %>


### PR DESCRIPTION
by security reason, omniauth_authorize_path should be accessed via POST by default like devise 4.8.0.
https://github.com/heartcombo/devise/blob/master/CHANGELOG.md

since users who prefer GET can customize the behavior by users' side, this change should be fine.
