### PR TITLE
Migrate CI from Travis CI to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby-version:
+          - 2.5
+          - 2.6
+          - 2.7
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "${{ matrix.ruby-version }}"
+          bundler-cache: true
+      - run: bundle exec rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-rvm:
-  - 2.5.7
-  - 2.6.5
-  - 2.7.0
-
-before_install:
-  - gem uninstall bundler || true
-  - gem install bundler --version '1.17.2'

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # devise-i18n
 
-[![Build Status](https://secure.travis-ci.org/tigrish/devise-i18n.png)](http://travis-ci.org/tigrish/devise-i18n)
+[![CI](https://github.com/tigrish/devise-i18n/actions/workflows/ci.yml/badge.svg)](https://github.com/tigrish/devise-i18n/actions/workflows/ci.yml)
 
 [Devise](https://github.com/plataformatec/devise) "is a flexible authentication solution for Rails based on Warden". Internationalization (aka i18n) is a "means of adapting computer software to different languages, regional differences and technical requirements of a target market".
 


### PR DESCRIPTION
Since June 15th, 2021, the building on travis-ci.org is ceased. 
We can migrate to travis-ci.com, but I found this comment from https://github.com/tigrish/devise-i18n/pull/291#issuecomment-794624186.
> We're gonna have to move off of Travis as it's no longer free.

This PR migrates CI from Travis CI to GitHub Actions.