### PR TITLE
Use https for GitHub link

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -16,7 +16,7 @@ require 'jeweler'
 Jeweler::Tasks.new do |gem|
   # gem is a Gem::Specification... see http://docs.rubygems.org/read/chapter/20 for more options
   gem.name = "devise-i18n"
-  gem.homepage = "http://github.com/tigrish/devise-i18n"
+  gem.homepage = "https://github.com/tigrish/devise-i18n"
   gem.license = "MIT"
   gem.summary = %Q{Translations for the devise gem}
   gem.description = %Q{Translations for the devise gem}

--- a/devise-i18n.gemspec
+++ b/devise-i18n.gemspec
@@ -116,7 +116,7 @@ Gem::Specification.new do |s|
     "rails/locales/zh-TW.yml",
     "rails/locales/zh-YUE.yml"
   ]
-  s.homepage = "http://github.com/tigrish/devise-i18n".freeze
+  s.homepage = "https://github.com/tigrish/devise-i18n".freeze
   s.licenses = ["MIT".freeze]
   s.rubygems_version = "3.0.3".freeze
   s.summary = "Translations for the devise gem".freeze
@@ -160,4 +160,3 @@ Gem::Specification.new do |s|
     s.add_dependency(%q<omniauth-twitter>.freeze, [">= 0"])
   end
 end
-


### PR DESCRIPTION
This reduces unnecessary redirection from http://... to https://... when someone visits this gem's homepage via https://rubygems.org/gems/devise-i18n or some tools or APIs that use the gem's metadata.