### PR TITLE
Update link for LocaleApp

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ which will generate `config/locales/devise.views.it.yml`. If you're doing this t
 
 ## Contributing translations to devise-i18n
 
-Edit the translations directly on the [devise-i18n](http://www.localeapp.com/projects/377) project on Locale. **That's it!**
-The maintainer will periodically pull translations from the Locale project and push to Github.
+Edit the translations directly on the [devise-i18n](https://app.localeapp.com/projects/377) project on Locale. **That's it!**
+The maintainer will periodically pull translations from the Locale project and push to GitHub.
 
 Alternately, you can create a pull request on GitHub.
 


### PR DESCRIPTION
This PR updates link for LocaleApp from http://www.localeapp.com/projects/377 to https://app.localeapp.com/projects/377.
And corrects Github to GitHub.