### PR TITLE
Add Ruby 3.0 and 3.1 to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
           - 2.5
           - 2.6
           - 2.7
+          - '3.0'
+          - 3.1
 
     steps:
       - uses: actions/checkout@v2

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,6 @@ source 'https://rubygems.org'
 group :development do
   gem "rspec", ">= 2.8.0"
   gem 'rspec-rails'
-  gem "bundler", "~> 1.2"
   gem "jeweler", git: 'https://github.com/technicalpickles/jeweler', ref: '2ab86309fc2494ba2a4e9c86c514742cd4f681c2'
   gem 'i18n-spec', "~> 0.6.0"
   gem 'localeapp'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -185,7 +185,6 @@ PLATFORMS
 
 DEPENDENCIES
   activemodel
-  bundler (~> 1.2)
   devise (>= 4.8.0)
   i18n-spec (~> 0.6.0)
   jeweler!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -195,4 +195,4 @@ DEPENDENCIES
   rspec-rails
 
 BUNDLED WITH
-   1.17.2
+   2.3.5

--- a/devise-i18n.gemspec
+++ b/devise-i18n.gemspec
@@ -128,7 +128,6 @@ Gem::Specification.new do |s|
       s.add_runtime_dependency(%q<devise>.freeze, [">= 4.8.0"])
       s.add_development_dependency(%q<rspec>.freeze, [">= 2.8.0"])
       s.add_development_dependency(%q<rspec-rails>.freeze, [">= 0"])
-      s.add_development_dependency(%q<bundler>.freeze, ["~> 1.2"])
       s.add_development_dependency(%q<jeweler>.freeze, [">= 0"])
       s.add_development_dependency(%q<i18n-spec>.freeze, ["~> 0.6.0"])
       s.add_development_dependency(%q<localeapp>.freeze, [">= 0"])
@@ -139,7 +138,6 @@ Gem::Specification.new do |s|
       s.add_dependency(%q<devise>.freeze, [">= 4.8.0"])
       s.add_dependency(%q<rspec>.freeze, [">= 2.8.0"])
       s.add_dependency(%q<rspec-rails>.freeze, [">= 0"])
-      s.add_dependency(%q<bundler>.freeze, ["~> 1.2"])
       s.add_dependency(%q<jeweler>.freeze, [">= 0"])
       s.add_dependency(%q<i18n-spec>.freeze, ["~> 0.6.0"])
       s.add_dependency(%q<localeapp>.freeze, [">= 0"])
@@ -151,7 +149,6 @@ Gem::Specification.new do |s|
     s.add_dependency(%q<devise>.freeze, [">= 4.8.0"])
     s.add_dependency(%q<rspec>.freeze, [">= 2.8.0"])
     s.add_dependency(%q<rspec-rails>.freeze, [">= 0"])
-    s.add_dependency(%q<bundler>.freeze, ["~> 1.2"])
     s.add_dependency(%q<jeweler>.freeze, [">= 0"])
     s.add_dependency(%q<i18n-spec>.freeze, ["~> 0.6.0"])
     s.add_dependency(%q<localeapp>.freeze, [">= 0"])
@@ -160,4 +157,3 @@ Gem::Specification.new do |s|
     s.add_dependency(%q<omniauth-twitter>.freeze, [">= 0"])
   end
 end
-


### PR DESCRIPTION
This PR adds Ruby 3.0 and 3.1 to the CI matrix, and does the following:
* Remove Bundler from Gemfile and gemspec
  * Bundler was added in #262, and GitHub Actions does not have any problem without it. 
* Update Bundler to the latest version
