### PR TITLE
Problem solved with relative paths not changing when creating Scoped view.

### DIFF
--- a/lib/generators/devise/i18n/views_generator.rb
+++ b/lib/generators/devise/i18n/views_generator.rb
@@ -29,7 +29,7 @@ module Devise
       def view_directory(name, target_path = nil)
         directory name.to_s, target_path || "#{default_target_path}/#{name}" do |content|
           if scope
-            content.gsub "devise/shared/links", "#{plural_scope}/shared/links"
+            content.gsub "devise/shared", "#{plural_scope}/shared"
           else
             content
           end


### PR DESCRIPTION
Nice to meet you!
My name is @lef237 and I am using `devise-i18n` in Japan.

Resolved an issue where relative paths were not changed when creating Scoped views such as `rails g devise:i18n:views user`.

Specifically, the problem is related to files such as `app/views/users/passwords` and `app/views/users/confirmations/new`.

Before
```rb
<%= render "devise/shared/error_messages", resource: resource %>
```
After
```rb
<%= render "users/shared/error_messages", resource: resource %>
```

As for the code changes, I referred to the `devise` code in the following link.
[devise/views_generator.rb at main · heartcombo/devise](https://github.com/heartcombo/devise/blob/main/lib/generators/devise/views_generator.rb#L42-L50)

Sincerely.