### PR TITLE
Handle capitalization of model name in error messages

### DIFF
--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,4 +1,4 @@
-<h2><%= t('.title', resource: resource.model_name.human) %></h2>
+<h2><%= t('.title', resource: devise_i18n_fix_model_name_case(resource.model_name.human, i18n_key: 'registrations.edit.title')) %></h2>
 
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>

--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -3,7 +3,7 @@
     <h2>
       <%= I18n.t("errors.messages.not_saved",
                  count: resource.errors.count,
-                 resource: resource.class.model_name.human.downcase)
+                 resource: devise_i18n_fix_model_name_case(resource.model_name.human, i18n_key: 'errors.messages.not_saved'))
        %>
     </h2>
     <ul>

--- a/lib/devise-i18n/railtie.rb
+++ b/lib/devise-i18n/railtie.rb
@@ -1,8 +1,14 @@
 require 'rails'
+require 'devise-i18n/view_helpers'
 
 module DeviseI18n
-  # This adds the views to view path
   class Engine < ::Rails::Engine
+    isolate_namespace DeviseI18n
+    initializer 'devise_i18n.action_controller' do
+      ActiveSupport.on_load :action_controller do
+        helper DeviseI18n::ViewHelpers
+      end
+    end
   end
 
   class Railtie < ::Rails::Railtie #:nodoc:

--- a/lib/devise-i18n/view_helpers.rb
+++ b/lib/devise-i18n/view_helpers.rb
@@ -1,0 +1,11 @@
+module DeviseI18n
+  module ViewHelpers
+    # Custom logic to fix case for different strings and languages.
+    def devise_i18n_fix_model_name_case(text, i18n_key:)
+      # In general, on errors.messages.not_saved, downcase, but German nouns are always capitalized.
+      return text.downcase if i18n_key == 'errors.messages.not_saved' && I18n.locale.to_s != 'de'
+
+      text
+    end
+  end
+end

--- a/lib/generators/devise/templates/simple_form_for/registrations/edit.html.erb
+++ b/lib/generators/devise/templates/simple_form_for/registrations/edit.html.erb
@@ -1,4 +1,4 @@
-<h2><%= t(".title", resource: resource.model_name.human) %></h2>
+<h2><%= t(".title", resource: devise_i18n_fix_model_name_case(resource.model_name.human, i18n_key: "registrations.edit.title")) %></h2>
 
 <%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
   <%= f.error_notification %>

--- a/spec/support/devise_i18n_views_app.rb
+++ b/spec/support/devise_i18n_views_app.rb
@@ -1,6 +1,7 @@
 require "action_controller/railtie"
 require "active_model"
 require 'omniauth-twitter'
+require 'devise-i18n/view_helpers'
 
 class User
   def email
@@ -109,6 +110,7 @@ end
 
 class TestController < ActionController::Base
   helper TestHelper
+  helper DeviseI18n::ViewHelpers
 
   before_action do
     instance_variable_set(:@view_paths, [])

--- a/spec/views_spec.rb
+++ b/spec/views_spec.rb
@@ -53,5 +53,23 @@ RSpec.describe TestController, type: :controller do
       end
     end
   end
+
+  describe 'capitalization special cases' do
+    before do
+      DeviseI18nViewsApp.view_to_render = 'devise/registrations/edit'
+      allow(I18n).to receive(:load_path).and_return(Dir[Rails.root.join('rails', 'locales', '*.yml')])
+    end
+
+    it 'retains capitalization of German nouns' do
+      I18n.locale = :de
+      # This should be capitalized regardless because it's the start of the sentence...
+      expect(render_devise_i18n_view).to include('User konnte aufgrund eines Fehlers nicht gespeichert werden:')
+    end
+
+    it 'downcases non-German nouns' do
+      I18n.locale = :en
+      expect(render_devise_i18n_view).to include('1 error prohibited this user from being saved:')
+    end
+  end
 end
 


### PR DESCRIPTION
Previously, we would always downcase the model name in the error partial. In some languages, this is not appropriate. For example, in German, nouns are always capitalized. In addition, the translated string might put the model name first, so it should still be capitalized.

There's not an elegant way to handle these kinds of rules, so we now define a helper devise_i18n_fix_model_name_case which capitalizes appropriately for the situation. The current implementation downcases in all cases, except in the error partial in German.

Fixes #260