### PR TITLE
Add Ruby 3.2 to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,10 @@ jobs:
           - 2.7
           - '3.0'
           - 3.1
+          - 3.2
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "${{ matrix.ruby-version }}"


### PR DESCRIPTION
This PR adds Ruby 3.2 to the CI matrix, and does the following:
- Bump actions/checkout to v3