### PR TITLE
Ignore loading helper in API-based controller

### DIFF
--- a/lib/devise-i18n/railtie.rb
+++ b/lib/devise-i18n/railtie.rb
@@ -6,7 +6,7 @@ module DeviseI18n
     isolate_namespace DeviseI18n
     initializer 'devise_i18n.action_controller' do
       ActiveSupport.on_load :action_controller do
-        helper DeviseI18n::ViewHelpers
+        helper DeviseI18n::ViewHelpers if respond_to?(:helper)
       end
     end
   end

--- a/spec/support/devise_i18n_views_app.rb
+++ b/spec/support/devise_i18n_views_app.rb
@@ -122,3 +122,6 @@ class TestController < ActionController::Base
     render DeviseI18nViewsApp.view_to_render
   end
 end
+
+class TestApiController < ActionController::API
+end


### PR DESCRIPTION
If a controller based on ActionController::API exists, it no longer works with devise-i18n 1.11.1.
The API does not use view helper, so I have changed it to not load it if the `helper` method is not present

```
NoMethodError:
  undefined method `helper' for ActionController::API:Class
# /usr/local/bundle/gems/devise-i18n-1.11.1/lib/devise-i18n/railtie.rb:9:in `block (2 levels) in <class:Engine>'
# /usr/local/bundle/gems/bootsnap-1.16.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
# /usr/local/bundle/gems/zeitwerk-2.6.12/lib/zeitwerk/kernel.rb:38:in `require'
# /usr/local/bundle/gems/doorkeeper-5.6.6/lib/doorkeeper/config.rb:477:in `resolve_controller'
# /usr/local/bundle/gems/doorkeeper-5.6.6/app/controllers/doorkeeper/application_metal_controller.rb:5:in `<module:Doorkeeper>'
# /usr/local/bundle/gems/doorkeeper-5.6.6/app/controllers/doorkeeper/application_metal_controller.rb:3:in `<top (required)>'
... snip ...
```