### PR TITLE
Add Ruby 3.3 to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
           - '3.0'
           - 3.1
           - 3.2
+          - 3.3
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
This PR adds Ruby 3.3 to the CI matrix.