### PR TITLE
Specify nokogiri 1.15.5 for Ruby 2.7

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -1,6 +1,6 @@
 # This only exists to specify an earlier version of nokogiri that is installable with Ruby 2.7.
 appraise "ruby-2.7" do
-  gem "nokogiri", "<1.16.0"
+  gem "nokogiri", "1.15.5"
 end
 
 appraise "ruby-3.0" do

--- a/gemfiles/ruby_2.7.gemfile
+++ b/gemfiles/ruby_2.7.gemfile
@@ -2,6 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "nokogiri", "<1.16.0"
+gem "nokogiri", "1.15.5"
 
 gemspec path: "../"

--- a/gemfiles/ruby_2.7.gemfile.lock
+++ b/gemfiles/ruby_2.7.gemfile.lock
@@ -87,7 +87,7 @@ GEM
     minitest (5.23.1)
     mutex_m (0.2.0)
     netrc (0.11.0)
-    nokogiri (1.15.6)
+    nokogiri (1.15.5)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     oauth (1.1.0)
@@ -192,7 +192,7 @@ DEPENDENCIES
   devise-i18n!
   i18n-spec (~> 0.6.0)
   localeapp
-  nokogiri (< 1.16.0)
+  nokogiri (= 1.15.5)
   omniauth-twitter
   railties
   rspec (>= 2.8.0)


### PR DESCRIPTION
1.15.6 seems to not compile in GH actions