### PR TITLE
Provide a 'Changelog' link on rubygems.org/gems/devise-i18n

### DIFF
--- a/devise-i18n.gemspec
+++ b/devise-i18n.gemspec
@@ -30,5 +30,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency(%q<activemodel>.freeze, [">= 0"])
   s.add_development_dependency(%q<omniauth-twitter>.freeze, [">= 0"])
   s.add_development_dependency(%q<appraisal>.freeze, [">= 0"])
-end
 
+  s.metadata["changelog_uri"] = s.homepage + "/blob/master/CHANGELOG.md"
+end


### PR DESCRIPTION
By providing a 'changelog_uri' in the metadata of the gemspec a 'Changelog' link will be shown on https://rubygems.org/gems/devise-i18n which makes it quick and easy for someone to check on the changes introduced with a new version.

Details of this functionality can be found on https://guides.rubygems.org/specification-reference/